### PR TITLE
test(mutant): Replace deprecated MutantBuilder::materialize(), simplify the builder

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -8065,80 +8065,6 @@ message = "Type `iterable` in return type of `mutantProvider` is imprecise, equi
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/MutantBuilder.php"
-code = "possibly-invalid-argument"
-message = '''
-Possible argument type mismatch for argument #3 of `Infection\Tests\Mutant\MutantBuilder::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('<?php
-
-namespace Acme;
-
-class Foo
-{
-    public function bar(): void
-    {
-        // Mutated: removed for loop
-    }
-}
-')>`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantBuilder.php"
-code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #3 of `Infection\Tests\Mutant\MutantBuilder::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('<?php $a = 2;')>`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantBuilder.php"
-code = "possibly-invalid-argument"
-message = '''
-Possible argument type mismatch for argument #4 of `Infection\Tests\Mutant\MutantBuilder::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('--- Original
-+++ Mutated
-@@ @@
--        for ($i = 0; $i < 10; $i++) {
--            echo $i;
--        }
-+        // Mutated: removed for loop')>`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantBuilder.php"
-code = "possibly-invalid-argument"
-message = '''
-Possible argument type mismatch for argument #4 of `Infection\Tests\Mutant\MutantBuilder::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('--- Original
-+++ Mutated
-@@ @@
--$a = 1;
-+$a = 2;')>`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantBuilder.php"
-code = "possibly-invalid-argument"
-message = '''
-Possible argument type mismatch for argument #5 of `Infection\Tests\Mutant\MutantBuilder::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('<?php
-
-namespace Acme;
-
-class Foo
-{
-    public function bar(): void
-    {
-        for ($i = 0; $i < 10; $i++) {
-            echo $i;
-        }
-    }
-}
-')>`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantBuilder.php"
-code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #5 of `Infection\Tests\Mutant\MutantBuilder::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('<?php $a = 1;')>`.'''
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutant/MutantBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutantBuilder` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -8277,12 +8203,6 @@ file = "tests/phpunit/Mutant/MutantTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 6
 
 [[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
@@ -10590,12 +10510,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
 code = "impossible-assignment"
 message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
 count = 1
@@ -10731,12 +10645,6 @@ file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 11
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -11675,34 +11583,10 @@ message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\
 count = 1
 
 [[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 3
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideValidVersions` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\Tests\Mutant\MutantBuilder::materialize`.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Common/VersionParserTest.php"

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1393,15 +1393,6 @@ parameters:
 			path: ../tests/phpunit/MockedContainer.php
 
 		-
-			rawMessage: '''
-				Call to deprecated method materialize() of class Infection\Tests\Mutant\MutantBuilder:
-				use `::withMinimalTestData()` or `::withCompleteTestData()` instead
-			'''
-			identifier: staticMethod.deprecated
-			count: 6
-			path: ../tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
-
-		-
 			rawMessage: 'Parameter #3 $mutators of method Infection\Mutation\FileMutationGenerator::generate() expects array<Infection\Mutator\Mutator<PhpParser\Node>>, array{Infection\Mutator\Arithmetic\Plus} given.'
 			identifier: argument.type
 			count: 1
@@ -1708,24 +1699,6 @@ parameters:
 			path: ../tests/phpunit/PhpParser/Visitor/VisitorTestCase/ConcreteVisitorTestCase.php
 
 		-
-			rawMessage: '''
-				Call to deprecated method materialize() of class Infection\Tests\Mutant\MutantBuilder:
-				use `::withMinimalTestData()` or `::withCompleteTestData()` instead
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method materialize() of class Infection\Tests\Mutant\MutantBuilder:
-				use `::withMinimalTestData()` or `::withCompleteTestData()` instead
-			'''
-			identifier: staticMethod.deprecated
-			count: 11
-			path: ../tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
-
-		-
 			rawMessage: 'Method Infection\Tests\Process\Runner\MutationTestingRunnerTest::emptyIterable() return type with generic class PHPUnit\Framework\Constraint\Callback does not specify its types: CallbackInput'
 			identifier: missingType.generics
 			count: 1
@@ -1844,42 +1817,6 @@ parameters:
 			identifier: argument.templateType
 			count: 1
 			path: ../tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method materialize() of class Infection\Tests\Mutant\MutantBuilder:
-				use `::withMinimalTestData()` or `::withCompleteTestData()` instead
-			'''
-			identifier: staticMethod.deprecated
-			count: 5
-			path: ../tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method materialize() of class Infection\Tests\Mutant\MutantBuilder:
-				use `::withMinimalTestData()` or `::withCompleteTestData()` instead
-			'''
-			identifier: staticMethod.deprecated
-			count: 3
-			path: ../tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method materialize() of class Infection\Tests\Mutant\MutantBuilder:
-				use `::withMinimalTestData()` or `::withCompleteTestData()` instead
-			'''
-			identifier: staticMethod.deprecated
-			count: 4
-			path: ../tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php
-
-		-
-			rawMessage: '''
-				Call to deprecated method materialize() of class Infection\Tests\Mutant\MutantBuilder:
-				use `::withMinimalTestData()` or `::withCompleteTestData()` instead
-			'''
-			identifier: staticMethod.deprecated
-			count: 3
-			path: ../tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
 
 		-
 			rawMessage: Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\DemoReportLocator should not exist

--- a/tests/phpunit/Mutant/MutantBuilder.php
+++ b/tests/phpunit/Mutant/MutantBuilder.php
@@ -39,22 +39,16 @@ use Infection\Mutant\Mutant;
 use Infection\Mutation\Mutation;
 use Infection\Tests\Mutation\MutationBuilder;
 use InvalidArgumentException;
-use Later\Interfaces\Deferred;
 use function Later\now;
 
 final class MutantBuilder
 {
-    /**
-     * @param Deferred<string> $mutatedCode
-     * @param Deferred<string> $diff
-     * @param Deferred<string> $prettyPrintedOriginalCode
-     */
     private function __construct(
         private string $mutantFilePath,
         private Mutation $mutation,
-        private Deferred $mutatedCode,
-        private Deferred $diff,
-        private Deferred $prettyPrintedOriginalCode,
+        private string $mutatedCode,
+        private string $diff,
+        private string $prettyPrintedOriginalCode,
     ) {
     }
 
@@ -63,9 +57,9 @@ final class MutantBuilder
         return new self(
             $mutant->getFilePath(),
             $mutant->getMutation(),
-            $mutant->getMutatedCode(),
-            $mutant->getDiff(),
-            $mutant->getPrettyPrintedOriginalCode(),
+            $mutant->getMutatedCode()->get(),
+            $mutant->getDiff()->get(),
+            $mutant->getPrettyPrintedOriginalCode()->get(),
         );
     }
 
@@ -86,9 +80,9 @@ final class MutantBuilder
         return self::withMinimalTestData()
             ->withMutantFilePath($mutantFilePath)
             ->withMutation($mutation)
-            ->withMutatedCode(now($mutatedCode))
-            ->withDiff(now($diff))
-            ->withPrettyPrintedOriginalCode(now($prettyPrintedOriginalCode))
+            ->withMutatedCode($mutatedCode)
+            ->withDiff($diff)
+            ->withPrettyPrintedOriginalCode($prettyPrintedOriginalCode)
             ->build();
     }
 
@@ -97,25 +91,19 @@ final class MutantBuilder
         return new self(
             mutantFilePath: '/path/to/mutant',
             mutation: MutationBuilder::withMinimalTestData()->build(),
-            mutatedCode: now(
-                <<<'PHP'
-                    <?php $a = 2;
-                    PHP,
-            ),
-            diff: now(
-                <<<'PHP'
-                    --- Original
-                    +++ Mutated
-                    @@ @@
-                    -$a = 1;
-                    +$a = 2;
-                    PHP,
-            ),
-            prettyPrintedOriginalCode: now(
-                <<<'PHP'
-                    <?php $a = 1;
-                    PHP,
-            ),
+            mutatedCode: <<<'PHP'
+                <?php $a = 2;
+                PHP,
+            diff: <<<'PHP'
+                --- Original
+                +++ Mutated
+                @@ @@
+                -$a = 1;
+                +$a = 2;
+                PHP,
+            prettyPrintedOriginalCode: <<<'PHP'
+                <?php $a = 1;
+                PHP,
         );
     }
 
@@ -124,51 +112,45 @@ final class MutantBuilder
         return new self(
             mutantFilePath: '/path/to/src/mutants/Foo_mutant_0.php',
             mutation: MutationBuilder::withCompleteTestData()->build(),
-            mutatedCode: now(
-                <<<'PHP'
-                    <?php
+            mutatedCode: <<<'PHP'
+                <?php
 
-                    namespace Acme;
+                namespace Acme;
 
-                    class Foo
+                class Foo
+                {
+                    public function bar(): void
                     {
-                        public function bar(): void
-                        {
-                            // Mutated: removed for loop
+                        // Mutated: removed for loop
+                    }
+                }
+
+                PHP,
+            diff: <<<'PHP'
+                --- Original
+                +++ Mutated
+                @@ @@
+                -        for ($i = 0; $i < 10; $i++) {
+                -            echo $i;
+                -        }
+                +        // Mutated: removed for loop
+                PHP,
+            prettyPrintedOriginalCode: <<<'PHP'
+                <?php
+
+                namespace Acme;
+
+                class Foo
+                {
+                    public function bar(): void
+                    {
+                        for ($i = 0; $i < 10; $i++) {
+                            echo $i;
                         }
                     }
+                }
 
-                    PHP,
-            ),
-            diff: now(
-                <<<'PHP'
-                    --- Original
-                    +++ Mutated
-                    @@ @@
-                    -        for ($i = 0; $i < 10; $i++) {
-                    -            echo $i;
-                    -        }
-                    +        // Mutated: removed for loop
-                    PHP,
-            ),
-            prettyPrintedOriginalCode: now(
-                <<<'PHP'
-                    <?php
-
-                    namespace Acme;
-
-                    class Foo
-                    {
-                        public function bar(): void
-                        {
-                            for ($i = 0; $i < 10; $i++) {
-                                echo $i;
-                            }
-                        }
-                    }
-
-                    PHP,
-            ),
+                PHP,
         );
     }
 
@@ -188,10 +170,7 @@ final class MutantBuilder
         return $clone;
     }
 
-    /**
-     * @param Deferred<string> $mutatedCode
-     */
-    public function withMutatedCode(Deferred $mutatedCode): self
+    public function withMutatedCode(string $mutatedCode): self
     {
         $clone = clone $this;
         $clone->mutatedCode = $mutatedCode;
@@ -199,10 +178,7 @@ final class MutantBuilder
         return $clone;
     }
 
-    /**
-     * @param Deferred<string> $diff
-     */
-    public function withDiff(Deferred $diff): self
+    public function withDiff(string $diff): self
     {
         $clone = clone $this;
         $clone->diff = $diff;
@@ -210,10 +186,7 @@ final class MutantBuilder
         return $clone;
     }
 
-    /**
-     * @param Deferred<string> $prettyPrintedOriginalCode
-     */
-    public function withPrettyPrintedOriginalCode(Deferred $prettyPrintedOriginalCode): self
+    public function withPrettyPrintedOriginalCode(string $prettyPrintedOriginalCode): self
     {
         $clone = clone $this;
         $clone->prettyPrintedOriginalCode = $prettyPrintedOriginalCode;
@@ -226,9 +199,9 @@ final class MutantBuilder
         return new Mutant(
             $this->mutantFilePath,
             $this->mutation,
-            $this->mutatedCode,
-            $this->diff,
-            $this->prettyPrintedOriginalCode,
+            now($this->mutatedCode),
+            now($this->diff),
+            now($this->prettyPrintedOriginalCode),
         );
     }
 }

--- a/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
@@ -45,7 +45,6 @@ use Infection\PhpParser\MutatedNode;
 use Infection\Process\DryRunProcess;
 use Infection\Process\MutantProcess;
 use Infection\Testing\MutatorName;
-use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -117,8 +116,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('notCovered#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('notCovered#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -126,8 +125,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'notCovered#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -197,8 +196,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('timedOut#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('timedOut#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -206,8 +205,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'timedOut#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -283,8 +282,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('errored#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('errored#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -292,8 +291,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'errored#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -370,8 +369,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('escaped#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('escaped#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -379,8 +378,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -457,8 +456,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('killed#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('killed#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -466,8 +465,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -553,8 +552,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('killed#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('killed#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -562,8 +561,8 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );

--- a/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/Mutant/TestFrameworkMutantExecutionResultFactoryTest.php
@@ -45,6 +45,7 @@ use Infection\PhpParser\MutatedNode;
 use Infection\Process\DryRunProcess;
 use Infection\Process\MutantProcess;
 use Infection\Testing\MutatorName;
+use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -94,9 +95,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -115,9 +116,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     [],
                     [],
                     '',
-                ),
-                'notCovered#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('notCovered#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -125,9 +126,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'notCovered#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -168,9 +169,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -195,9 +196,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'timedOut#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('timedOut#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -205,9 +206,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'timedOut#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
         $mutantProcess->markAsTimedOut();
@@ -254,9 +255,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -281,9 +282,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'errored#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('errored#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -291,9 +292,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'errored#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -341,9 +342,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -368,9 +369,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'escaped#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('escaped#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -378,9 +379,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -428,9 +429,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -455,9 +456,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'killed#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('killed#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -465,9 +466,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -524,9 +525,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -551,9 +552,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'killed#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('killed#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -561,9 +562,9 @@ final class TestFrameworkMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -47,6 +47,7 @@ use Infection\Tests\Configuration\ConfigurationBuilder;
 use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultBuilder;
+use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -60,9 +61,9 @@ final class MutantProcessContainerFactoryTest extends TestCase
     #[DataProvider('timeoutDataProvider')]
     public function test_it_creates_a_process_with_timeout(float $expectedProcessTimeout, float $testLocationExecutionTime, int $processFactoryTimeout): void
     {
-        $mutant = MutantBuilder::materialize(
-            $mutantFilePath = '/path/to/mutant',
-            new Mutation(
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath($mutantFilePath = '/path/to/mutant')
+            ->withMutation(new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
                 [],
                 For_::class,
@@ -87,9 +88,9 @@ final class MutantProcessContainerFactoryTest extends TestCase
                 ],
                 [],
                 '',
-            ),
-            'killed#0',
-            $mutantDiff = <<<'DIFF'
+            ))
+            ->withMutatedCode(now('killed#0'))
+            ->withDiff(now($mutantDiff = <<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -97,9 +98,9 @@ final class MutantProcessContainerFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF,
-            '<?php $a = 1;',
-        );
+                DIFF))
+            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+            ->build();
 
         $testFrameworkExtraOptions = '--verbose';
 

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -47,7 +47,6 @@ use Infection\Tests\Configuration\ConfigurationBuilder;
 use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultBuilder;
-use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -89,8 +88,8 @@ final class MutantProcessContainerFactoryTest extends TestCase
                 [],
                 '',
             ))
-            ->withMutatedCode(now('killed#0'))
-            ->withDiff(now($mutantDiff = <<<'DIFF'
+            ->withMutatedCode('killed#0')
+            ->withDiff($mutantDiff = <<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -98,8 +97,8 @@ final class MutantProcessContainerFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF))
-            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                DIFF)
+            ->withPrettyPrintedOriginalCode('<?php $a = 1;')
             ->build();
 
         $testFrameworkExtraOptions = '--verbose';

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -61,7 +61,6 @@ use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultBuilder;
 use Infection\Tests\WithConsecutive;
-use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -158,12 +157,12 @@ final class MutationTestingRunnerTest extends TestCase
                 $mutant0 = MutantBuilder::withMinimalTestData()
                     ->withMutantFilePath('/path/to/mutant0')
                     ->withMutation($mutation0)
-                    ->withMutatedCode(now('mutated code 0'))
+                    ->withMutatedCode('mutated code 0')
                     ->build(),
                 $mutant1 = MutantBuilder::withMinimalTestData()
                     ->withMutantFilePath('/path/to/mutant1')
                     ->withMutation($mutation1)
-                    ->withMutatedCode(now('mutated code 1'))
+                    ->withMutatedCode('mutated code 1')
                     ->build(),
                 MutantBuilder::withMinimalTestData()
                     ->withMutation($mutation2)
@@ -250,7 +249,7 @@ final class MutationTestingRunnerTest extends TestCase
                 $mutant0 = MutantBuilder::withMinimalTestData()
                     ->withMutantFilePath('/path/to/mutant0')
                     ->withMutation($mutation0)
-                    ->withMutatedCode(now('mutated code 0'))
+                    ->withMutatedCode('mutated code 0')
                     ->build(),
             )
         ;
@@ -327,12 +326,12 @@ final class MutationTestingRunnerTest extends TestCase
                 $mutant0 = MutantBuilder::withMinimalTestData()
                     ->withMutantFilePath('/path/to/mutant0')
                     ->withMutation($mutation0)
-                    ->withMutatedCode(now('mutated code 0'))
+                    ->withMutatedCode('mutated code 0')
                     ->build(),
                 $mutant1 = MutantBuilder::withMinimalTestData()
                     ->withMutantFilePath('/path/to/mutant1')
                     ->withMutation($mutation1)
-                    ->withMutatedCode(now('mutated code 1'))
+                    ->withMutatedCode('mutated code 1')
                     ->build(),
             )
         ;
@@ -400,8 +399,8 @@ final class MutationTestingRunnerTest extends TestCase
         $mutant = MutantBuilder::withMinimalTestData()
             ->withMutantFilePath('/path/to/mutant0')
             ->withMutation($mutation0)
-            ->withMutatedCode(now('mutated code 0'))
-            ->withDiff(now('- Assert::integer(1)'))
+            ->withMutatedCode('mutated code 0')
+            ->withDiff('- Assert::integer(1)')
             ->build();
 
         $this->mutantFactoryMock
@@ -466,8 +465,8 @@ final class MutationTestingRunnerTest extends TestCase
         $mutant = MutantBuilder::withMinimalTestData()
             ->withMutantFilePath('/path/to/mutant0')
             ->withMutation($mutation0)
-            ->withMutatedCode(now('mutated code 0'))
-            ->withDiff(now('- Assert::integer(1)'))
+            ->withMutatedCode('mutated code 0')
+            ->withDiff('- Assert::integer(1)')
             ->build();
 
         $this->mutantFactoryMock
@@ -545,7 +544,7 @@ final class MutationTestingRunnerTest extends TestCase
 
         $mutant = MutantBuilder::withMinimalTestData()
             ->withMutation($mutation)
-            ->withMutatedCode(now('mutated code 0'))
+            ->withMutatedCode('mutated code 0')
             ->build();
 
         $result = $this->invokeMethod('ignoredByRegex', $mutant);

--- a/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
+++ b/tests/phpunit/Process/Runner/MutationTestingRunnerTest.php
@@ -61,6 +61,7 @@ use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultBuilder;
 use Infection\Tests\WithConsecutive;
+use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -154,22 +155,22 @@ final class MutationTestingRunnerTest extends TestCase
                 [$mutation3],
             ))
             ->willReturnOnConsecutiveCalls(
-                $mutant0 = MutantBuilder::materialize(
-                    '/path/to/mutant0',
-                    $mutation0,
-                    'mutated code 0',
-                ),
-                $mutant1 = MutantBuilder::materialize(
-                    '/path/to/mutant1',
-                    $mutation1,
-                    'mutated code 1',
-                ),
-                MutantBuilder::materialize(
-                    mutation: $mutation2,
-                ),
-                MutantBuilder::materialize(
-                    mutation: $mutation3,
-                ),
+                $mutant0 = MutantBuilder::withMinimalTestData()
+                    ->withMutantFilePath('/path/to/mutant0')
+                    ->withMutation($mutation0)
+                    ->withMutatedCode(now('mutated code 0'))
+                    ->build(),
+                $mutant1 = MutantBuilder::withMinimalTestData()
+                    ->withMutantFilePath('/path/to/mutant1')
+                    ->withMutation($mutation1)
+                    ->withMutatedCode(now('mutated code 1'))
+                    ->build(),
+                MutantBuilder::withMinimalTestData()
+                    ->withMutation($mutation2)
+                    ->build(),
+                MutantBuilder::withMinimalTestData()
+                    ->withMutation($mutation3)
+                    ->build(),
             )
         ;
 
@@ -246,11 +247,11 @@ final class MutationTestingRunnerTest extends TestCase
                 [$mutation0],
             ))
             ->willReturn(
-                $mutant0 = MutantBuilder::materialize(
-                    '/path/to/mutant0',
-                    $mutation0,
-                    'mutated code 0',
-                ),
+                $mutant0 = MutantBuilder::withMinimalTestData()
+                    ->withMutantFilePath('/path/to/mutant0')
+                    ->withMutation($mutation0)
+                    ->withMutatedCode(now('mutated code 0'))
+                    ->build(),
             )
         ;
 
@@ -323,16 +324,16 @@ final class MutationTestingRunnerTest extends TestCase
                 [$mutation1],
             ))
             ->willReturnOnConsecutiveCalls(
-                $mutant0 = MutantBuilder::materialize(
-                    '/path/to/mutant0',
-                    $mutation0,
-                    'mutated code 0',
-                ),
-                $mutant1 = MutantBuilder::materialize(
-                    '/path/to/mutant1',
-                    $mutation1,
-                    'mutated code 1',
-                ),
+                $mutant0 = MutantBuilder::withMinimalTestData()
+                    ->withMutantFilePath('/path/to/mutant0')
+                    ->withMutation($mutation0)
+                    ->withMutatedCode(now('mutated code 0'))
+                    ->build(),
+                $mutant1 = MutantBuilder::withMinimalTestData()
+                    ->withMutantFilePath('/path/to/mutant1')
+                    ->withMutation($mutation1)
+                    ->withMutatedCode(now('mutated code 1'))
+                    ->build(),
             )
         ;
 
@@ -396,12 +397,12 @@ final class MutationTestingRunnerTest extends TestCase
 
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
-        $mutant = MutantBuilder::materialize(
-            '/path/to/mutant0',
-            $mutation0,
-            'mutated code 0',
-            '- Assert::integer(1)',
-        );
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath('/path/to/mutant0')
+            ->withMutation($mutation0)
+            ->withMutatedCode(now('mutated code 0'))
+            ->withDiff(now('- Assert::integer(1)'))
+            ->build();
 
         $this->mutantFactoryMock
             ->method('create')
@@ -462,12 +463,12 @@ final class MutationTestingRunnerTest extends TestCase
 
         $testFrameworkExtraOptions = '--filter=acme/FooTest.php';
 
-        $mutant = MutantBuilder::materialize(
-            '/path/to/mutant0',
-            $mutation0,
-            'mutated code 0',
-            '- Assert::integer(1)',
-        );
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath('/path/to/mutant0')
+            ->withMutation($mutation0)
+            ->withMutatedCode(now('mutated code 0'))
+            ->withDiff(now('- Assert::integer(1)'))
+            ->build();
 
         $this->mutantFactoryMock
             ->method('create')
@@ -542,10 +543,10 @@ final class MutationTestingRunnerTest extends TestCase
 
         $mutation = $this->createMutation(0);
 
-        $mutant = MutantBuilder::materialize(
-            mutation: $mutation,
-            mutatedCode: 'mutated code 0',
-        );
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutation($mutation)
+            ->withMutatedCode(now('mutated code 0'))
+            ->build();
 
         $result = $this->invokeMethod('ignoredByRegex', $mutant);
 
@@ -624,7 +625,7 @@ final class MutationTestingRunnerTest extends TestCase
     {
         $mutation = $this->createMutation(0, coveredByTests: false);
 
-        $mutant = MutantBuilder::materialize(mutation: $mutation);
+        $mutant = MutantBuilder::withMinimalTestData()->withMutation($mutation)->build();
 
         $result = $this->invokeMethod('uncoveredByTest', $mutant);
 

--- a/tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php
@@ -46,7 +46,6 @@ use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultAssertions;
-use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -109,8 +108,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('notCovered#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('notCovered#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -118,8 +117,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'notCovered#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -191,8 +190,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('errored#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('errored#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -200,8 +199,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'errored#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -275,8 +274,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('escaped#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('escaped#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -284,8 +283,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -364,8 +363,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('escaped#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('escaped#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -373,8 +372,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -439,8 +438,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('killed#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('killed#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -448,8 +447,8 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );

--- a/tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Mutant/MagoMutantExecutionResultFactoryTest.php
@@ -46,6 +46,7 @@ use Infection\StaticAnalysis\Mago\Mutant\MagoMutantExecutionResultFactory;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultAssertions;
+use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -86,9 +87,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -107,9 +108,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     [],
                     [],
                     '',
-                ),
-                'notCovered#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('notCovered#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -117,9 +118,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'notCovered#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -162,9 +163,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -189,9 +190,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'errored#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('errored#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -199,9 +200,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'errored#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -246,9 +247,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -273,9 +274,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'escaped#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('escaped#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -283,9 +284,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -335,9 +336,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -362,9 +363,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'escaped#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('escaped#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -372,9 +373,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
         $mutantProcess->markAsFinished();
@@ -410,9 +411,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -437,9 +438,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'killed#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('killed#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -447,9 +448,9 @@ final class MagoMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 

--- a/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
@@ -44,6 +44,7 @@ use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
 use Infection\TestFramework\Common\CommandLineBuilder;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
+use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -54,9 +55,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
 {
     public function test_it_creates_a_process_with_timeout(): void
     {
-        $mutant = MutantBuilder::materialize(
-            $mutantFilePath = '/path/to/mutant',
-            new Mutation(
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath($mutantFilePath = '/path/to/mutant')
+            ->withMutation(new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
                 [],
                 For_::class,
@@ -81,9 +82,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 ],
                 [],
                 '',
-            ),
-            'killed#0',
-            <<<'DIFF'
+            ))
+            ->withMutatedCode(now('killed#0'))
+            ->withDiff(now(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -91,9 +92,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF,
-            '<?php $a = 1;',
-        );
+                DIFF))
+            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+            ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
         $commandLineBuilder = $this->createMock(CommandLineBuilder::class);
@@ -135,9 +136,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
 
     public function test_it_creates_a_process_with_multiple_options(): void
     {
-        $mutant = MutantBuilder::materialize(
-            $mutantFilePath = '/path/to/mutant',
-            new Mutation(
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath($mutantFilePath = '/path/to/mutant')
+            ->withMutation(new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
                 [],
                 For_::class,
@@ -162,9 +163,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 ],
                 [],
                 '',
-            ),
-            'killed#0',
-            <<<'DIFF'
+            ))
+            ->withMutatedCode(now('killed#0'))
+            ->withDiff(now(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -172,9 +173,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF,
-            '<?php $a = 1;',
-        );
+                DIFF))
+            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+            ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
         $commandLineBuilder = $this->createMock(CommandLineBuilder::class);
@@ -221,9 +222,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
 
     public function test_it_creates_a_process_without_options(): void
     {
-        $mutant = MutantBuilder::materialize(
-            $mutantFilePath = '/path/to/mutant',
-            new Mutation(
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath($mutantFilePath = '/path/to/mutant')
+            ->withMutation(new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
                 [],
                 For_::class,
@@ -248,9 +249,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 ],
                 [],
                 '',
-            ),
-            'killed#0',
-            <<<'DIFF'
+            ))
+            ->withMutatedCode(now('killed#0'))
+            ->withDiff(now(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -258,9 +259,9 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF,
-            '<?php $a = 1;',
-        );
+                DIFF))
+            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+            ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
         $commandLineBuilder = $this->createMock(CommandLineBuilder::class);

--- a/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
@@ -44,7 +44,6 @@ use Infection\StaticAnalysis\Mago\Process\MagoMutantProcessFactory;
 use Infection\TestFramework\Common\CommandLineBuilder;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
-use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -83,8 +82,8 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 [],
                 '',
             ))
-            ->withMutatedCode(now('killed#0'))
-            ->withDiff(now(<<<'DIFF'
+            ->withMutatedCode('killed#0')
+            ->withDiff(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -92,8 +91,8 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF))
-            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                DIFF)
+            ->withPrettyPrintedOriginalCode('<?php $a = 1;')
             ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
@@ -164,8 +163,8 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 [],
                 '',
             ))
-            ->withMutatedCode(now('killed#0'))
-            ->withDiff(now(<<<'DIFF'
+            ->withMutatedCode('killed#0')
+            ->withDiff(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -173,8 +172,8 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF))
-            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                DIFF)
+            ->withPrettyPrintedOriginalCode('<?php $a = 1;')
             ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
@@ -250,8 +249,8 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 [],
                 '',
             ))
-            ->withMutatedCode(now('killed#0'))
-            ->withDiff(now(<<<'DIFF'
+            ->withMutatedCode('killed#0')
+            ->withDiff(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -259,8 +258,8 @@ final class MagoMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF))
-            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                DIFF)
+            ->withPrettyPrintedOriginalCode('<?php $a = 1;')
             ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);

--- a/tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php
@@ -46,7 +46,6 @@ use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultAssertions;
-use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -109,8 +108,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('notCovered#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('notCovered#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -118,8 +117,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'notCovered#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -191,8 +190,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('errored#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('errored#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -200,8 +199,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'errored#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -271,8 +270,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('escaped#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('escaped#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -280,8 +279,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );
@@ -352,8 +351,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     [],
                     '',
                 ))
-                ->withMutatedCode(now('killed#0'))
-                ->withDiff(now($mutantDiff = <<<'DIFF'
+                ->withMutatedCode('killed#0')
+                ->withDiff($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -361,8 +360,8 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF))
-                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                    DIFF)
+                ->withPrettyPrintedOriginalCode('<?php $a = 1;')
                 ->build(),
             $this->resultFactory,
         );

--- a/tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactoryTest.php
@@ -46,6 +46,7 @@ use Infection\StaticAnalysis\PHPStan\Mutant\PHPStanMutantExecutionResultFactory;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
 use Infection\Tests\Mutant\MutantExecutionResultAssertions;
+use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -86,9 +87,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -107,9 +108,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     [],
                     [],
                     '',
-                ),
-                'notCovered#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('notCovered#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -117,9 +118,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'notCovered#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -162,9 +163,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -189,9 +190,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'errored#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('errored#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -199,9 +200,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'errored#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -242,9 +243,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -269,9 +270,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'escaped#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('escaped#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -279,9 +280,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'escaped#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 
@@ -323,9 +324,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
 
         $mutantProcess = new MutantProcess(
             $processMock,
-            MutantBuilder::materialize(
-                '/path/to/mutant',
-                new Mutation(
+            MutantBuilder::withMinimalTestData()
+                ->withMutantFilePath('/path/to/mutant')
+                ->withMutation(new Mutation(
                     $originalFilePath = 'path/to/Foo.php',
                     [],
                     For_::class,
@@ -350,9 +351,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     ],
                     [],
                     '',
-                ),
-                'killed#0',
-                $mutantDiff = <<<'DIFF'
+                ))
+                ->withMutatedCode(now('killed#0'))
+                ->withDiff(now($mutantDiff = <<<'DIFF'
                     --- Original
                     +++ New
                     @@ @@
@@ -360,9 +361,9 @@ final class PHPStanMutantExecutionResultFactoryTest extends TestCase
                     - echo 'original';
                     + echo 'killed#0';
 
-                    DIFF,
-                '<?php $a = 1;',
-            ),
+                    DIFF))
+                ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                ->build(),
             $this->resultFactory,
         );
 

--- a/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
@@ -44,6 +44,7 @@ use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
 use Infection\TestFramework\Common\CommandLineBuilder;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
+use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -54,9 +55,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
 {
     public function test_it_creates_a_process_with_timeout(): void
     {
-        $mutant = MutantBuilder::materialize(
-            $mutantFilePath = '/path/to/mutant',
-            new Mutation(
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath($mutantFilePath = '/path/to/mutant')
+            ->withMutation(new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
                 [],
                 For_::class,
@@ -81,9 +82,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 ],
                 [],
                 '',
-            ),
-            'killed#0',
-            <<<'DIFF'
+            ))
+            ->withMutatedCode(now('killed#0'))
+            ->withDiff(now(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -91,9 +92,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF,
-            '<?php $a = 1;',
-        );
+                DIFF))
+            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+            ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
         $commandLineBuilder = $this->createMock(CommandLineBuilder::class);
@@ -151,9 +152,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
 
     public function test_it_creates_a_process_with_multiple_options(): void
     {
-        $mutant = MutantBuilder::materialize(
-            $mutantFilePath = '/path/to/mutant',
-            new Mutation(
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath($mutantFilePath = '/path/to/mutant')
+            ->withMutation(new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
                 [],
                 For_::class,
@@ -178,9 +179,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 ],
                 [],
                 '',
-            ),
-            'killed#0',
-            <<<'DIFF'
+            ))
+            ->withMutatedCode(now('killed#0'))
+            ->withDiff(now(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -188,9 +189,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF,
-            '<?php $a = 1;',
-        );
+                DIFF))
+            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+            ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
         $commandLineBuilder = $this->createMock(CommandLineBuilder::class);
@@ -249,9 +250,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
 
     public function test_it_creates_a_process_without_options(): void
     {
-        $mutant = MutantBuilder::materialize(
-            $mutantFilePath = '/path/to/mutant',
-            new Mutation(
+        $mutant = MutantBuilder::withMinimalTestData()
+            ->withMutantFilePath($mutantFilePath = '/path/to/mutant')
+            ->withMutation(new Mutation(
                 $originalFilePath = 'path/to/Foo.php',
                 [],
                 For_::class,
@@ -276,9 +277,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 ],
                 [],
                 '',
-            ),
-            'killed#0',
-            <<<'DIFF'
+            ))
+            ->withMutatedCode(now('killed#0'))
+            ->withDiff(now(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -286,9 +287,9 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF,
-            '<?php $a = 1;',
-        );
+                DIFF))
+            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+            ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
         $commandLineBuilder = $this->createMock(CommandLineBuilder::class);

--- a/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactoryTest.php
@@ -44,7 +44,6 @@ use Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory;
 use Infection\TestFramework\Common\CommandLineBuilder;
 use Infection\Testing\MutatorName;
 use Infection\Tests\Mutant\MutantBuilder;
-use function Later\now;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -83,8 +82,8 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 [],
                 '',
             ))
-            ->withMutatedCode(now('killed#0'))
-            ->withDiff(now(<<<'DIFF'
+            ->withMutatedCode('killed#0')
+            ->withDiff(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -92,8 +91,8 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF))
-            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                DIFF)
+            ->withPrettyPrintedOriginalCode('<?php $a = 1;')
             ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
@@ -180,8 +179,8 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 [],
                 '',
             ))
-            ->withMutatedCode(now('killed#0'))
-            ->withDiff(now(<<<'DIFF'
+            ->withMutatedCode('killed#0')
+            ->withDiff(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -189,8 +188,8 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF))
-            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                DIFF)
+            ->withPrettyPrintedOriginalCode('<?php $a = 1;')
             ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);
@@ -278,8 +277,8 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 [],
                 '',
             ))
-            ->withMutatedCode(now('killed#0'))
-            ->withDiff(now(<<<'DIFF'
+            ->withMutatedCode('killed#0')
+            ->withDiff(<<<'DIFF'
                 --- Original
                 +++ New
                 @@ @@
@@ -287,8 +286,8 @@ final class PHPStanMutantProcessFactoryTest extends TestCase
                 - echo 'original';
                 + echo 'killed#0';
 
-                DIFF))
-            ->withPrettyPrintedOriginalCode(now('<?php $a = 1;'))
+                DIFF)
+            ->withPrettyPrintedOriginalCode('<?php $a = 1;')
             ->build();
 
         $phpStanMutantExecutionResultFactory = $this->createStub(MutantExecutionResultFactory::class);


### PR DESCRIPTION
## Description

Let's put these away, and also let's reduce the `Deferred` spillover outside of `MutantBuilder`.

## Changes

- Only test related changes. All metrics should stay the same.
- About 179 lines of baselines removed

## Checklist

- [x] Tests added/updated
- [x] Appropriate labels applied (e.g. `performance`, `feature`).

