### PR TITLE
fix(architecture): Revert TurboNodeTraverser return type in Analyser

### DIFF
--- a/tests/Architecture/PHPat/Selector/Support/Analyser/Analyser.php
+++ b/tests/Architecture/PHPat/Selector/Support/Analyser/Analyser.php
@@ -48,7 +48,6 @@ use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\Parser;
 use PHPStan\Reflection\ClassReflection;
-use PHPStanTurbo\NodeTraverser as TurboNodeTraverser;
 use function sprintf;
 use Webmozart\Assert\Assert;
 
@@ -160,7 +159,7 @@ final class Analyser
         );
     }
 
-    private function createTraverser(?NodeVisitor ...$visitors): NodeTraverserInterface|TurboNodeTraverser
+    private function createTraverser(?NodeVisitor ...$visitors): NodeTraverserInterface
     {
         return new NodeTraverser(
             new ParentConnectingVisitor(),


### PR DESCRIPTION

## Description

Ondřej Mirtes [flagged](https://github.com/infection/infection/pull/3422#issuecomment-5159197953) the `NodeTraverserInterface|TurboNodeTraverser` union merged in #3422 as wrong; it was a workaround for a PHPStan bug that is fixed in phpstan/phpstan 2.2.7.

## Changes

- Reverts a change that is no longer needed.

