### PR TITLE
fix(reporter): Escape GitHub annotation workflow commands

### DIFF
--- a/src/Reporter/GitHubAnnotationsReporter.php
+++ b/src/Reporter/GitHubAnnotationsReporter.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace Infection\Reporter;
 
 use Infection\Metrics\ResultsCollector;
+use function sprintf;
 use function str_replace;
 use Symfony\Component\Filesystem\Path;
 
@@ -80,10 +81,27 @@ final readonly class GitHubAnnotationsReporter implements LineMutationTestingRes
      */
     private function buildAnnotation(string $filePath, array $error): string
     {
-        // new lines need to be encoded
-        // see https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448
-        $message = str_replace("\n", '%0A', $error['message']);
+        // Data and properties need to be escaped to avoid a file path or error message to hijack
+        // the GitHub annotations by leveraging the annotation delimiters.
+        //
+        // See:
+        // https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#about-workflow-commands
+        // https://github.com/actions/toolkit/blob/193fa46c20fde8b0ed54194bc08b841c78c0776d/packages/core/src/command.ts#L92-L111
+        return sprintf(
+            "::warning file=%s,line=%d::%s\n",
+            self::escapeProperty($filePath),
+            $error['line'],
+            self::escapeData($error['message']),
+        );
+    }
 
-        return "::warning file={$filePath},line={$error['line']}::{$message}\n";
+    private static function escapeData(string $value): string
+    {
+        return str_replace(['%', "\r", "\n"], ['%25', '%0D', '%0A'], $value);
+    }
+
+    private static function escapeProperty(string $value): string
+    {
+        return str_replace(['%', "\r", "\n", ':', ','], ['%25', '%0D', '%0A', '%3A', '%2C'], $value);
     }
 }

--- a/tests/phpunit/Reporter/CreateMetricsCalculator.php
+++ b/tests/phpunit/Reporter/CreateMetricsCalculator.php
@@ -181,13 +181,14 @@ trait CreateMetricsCalculator
         string $mutatorClassName,
         DetectionStatus $detectionStatus,
         string $echoMutatedMessage,
+        ?string $mutantDiff = null,
     ): MutantExecutionResult {
         return new MutantExecutionResult(
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
             'process output',
             $detectionStatus,
             now(
-                Str::rTrimLines(
+                $mutantDiff ?? Str::rTrimLines(
                     <<<DIFF
                         --- Original
                         +++ New

--- a/tests/phpunit/Reporter/CreateMetricsCalculator.php
+++ b/tests/phpunit/Reporter/CreateMetricsCalculator.php
@@ -182,6 +182,7 @@ trait CreateMetricsCalculator
         DetectionStatus $detectionStatus,
         string $echoMutatedMessage,
         ?string $mutantDiff = null,
+        ?string $originalFilePath = null,
     ): MutantExecutionResult {
         return new MutantExecutionResult(
             'bin/phpunit --configuration infection-tmp-phpunit.xml --filter "tests/Acme/FooTest.php"',
@@ -203,7 +204,7 @@ trait CreateMetricsCalculator
             'a1b2c3',
             $mutatorClassName,
             MutatorName::getName($mutatorClassName),
-            self::$originalFilePrefix . 'foo/bar',
+            $originalFilePath ?? self::$originalFilePrefix . 'foo/bar',
             10 - $i,
             20 - $i,
             10 - $i,

--- a/tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php
+++ b/tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php
@@ -36,6 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\Reporter;
 
 use Infection\Metrics\ResultsCollector;
+use Infection\Mutant\DetectionStatus;
+use Infection\Mutator\Loop\For_;
 use Infection\Reporter\GitHubAnnotationsReporter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -94,5 +96,26 @@ final class GitHubAnnotationsReporterTest extends TestCase
         $reporter = new GitHubAnnotationsReporter($resultsCollector, '/custom/project/dir/');
 
         $this->assertStringContainsString('warning file=foo/bar', $reporter->getLines()[0]);
+    }
+
+    public function test_it_escapes_github_command_data_and_properties(): void
+    {
+        self::setOriginalFilePrefix("/path/to/project/foo%,:\r\n");
+
+        $resultsCollector = new ResultsCollector();
+        $resultsCollector->collect(self::createMutantExecutionResult(
+            0,
+            For_::class,
+            DetectionStatus::ESCAPED,
+            'unused',
+            mutantDiff: "%\r\n::error::Injected",
+        ));
+
+        $reporter = new GitHubAnnotationsReporter($resultsCollector, '/path/to/project');
+
+        $this->assertSame(
+            "::warning file=foo%25%2C%3A%0D%0Afoo/bar,line=10::Escaped Mutant for Mutator \"For_\":%0A%0A%25%0D%0A::error::Injected\n",
+            $reporter->getLines()[0],
+        );
     }
 }

--- a/tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php
+++ b/tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php
@@ -37,6 +37,7 @@ namespace Infection\Tests\Reporter;
 
 use Infection\Metrics\ResultsCollector;
 use Infection\Mutant\DetectionStatus;
+use Infection\Mutant\MutantExecutionResult;
 use Infection\Mutator\Loop\For_;
 use Infection\Reporter\GitHubAnnotationsReporter;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -85,6 +86,37 @@ final class GitHubAnnotationsReporterTest extends TestCase
                 "::warning file=foo/bar,line=10::Escaped Mutant for Mutator \"For_\":%0A%0A--- Original%0A+++ New%0A@@ @@%0A%0A- echo 'original';%0A+ echo 'escaped#0';%0A\n",
             ],
         ];
+
+        yield 'reserved GitHub command data characters' => [
+            self::createResultsCollector(
+                self::createMutantExecutionResult(
+                    0,
+                    For_::class,
+                    DetectionStatus::ESCAPED,
+                    'unused',
+                    mutantDiff: "%\r\n::error::Injected",
+                ),
+            ),
+            [
+                "::warning file=foo/bar,line=10::Escaped Mutant for Mutator \"For_\":%0A%0A%25%0D%0A::error::Injected\n",
+            ],
+        ];
+
+        yield 'reserved GitHub command property characters' => [
+            self::createResultsCollector(
+                self::createMutantExecutionResult(
+                    0,
+                    For_::class,
+                    DetectionStatus::ESCAPED,
+                    'unused',
+                    mutantDiff: 'diff',
+                    originalFilePath: "/path/to/project/foo%,:\r\nfoo/bar",
+                ),
+            ),
+            [
+                "::warning file=foo%25%2C%3A%0D%0Afoo/bar,line=10::Escaped Mutant for Mutator \"For_\":%0A%0Adiff\n",
+            ],
+        ];
     }
 
     public function test_it_reports_correctly_with_custom_github_workspace(): void
@@ -98,24 +130,11 @@ final class GitHubAnnotationsReporterTest extends TestCase
         $this->assertStringContainsString('warning file=foo/bar', $reporter->getLines()[0]);
     }
 
-    public function test_it_escapes_github_command_data_and_properties(): void
+    private static function createResultsCollector(MutantExecutionResult ...$executionResults): ResultsCollector
     {
-        self::setOriginalFilePrefix("/path/to/project/foo%,:\r\n");
-
         $resultsCollector = new ResultsCollector();
-        $resultsCollector->collect(self::createMutantExecutionResult(
-            0,
-            For_::class,
-            DetectionStatus::ESCAPED,
-            'unused',
-            mutantDiff: "%\r\n::error::Injected",
-        ));
+        $resultsCollector->collect(...$executionResults);
 
-        $reporter = new GitHubAnnotationsReporter($resultsCollector, '/path/to/project');
-
-        $this->assertSame(
-            "::warning file=foo%25%2C%3A%0D%0Afoo/bar,line=10::Escaped Mutant for Mutator \"For_\":%0A%0A%25%0D%0A::error::Injected\n",
-            $reporter->getLines()[0],
-        );
+        return $resultsCollector;
     }
 }


### PR DESCRIPTION
## Description

Infection reports escaped mutants as GitHub Actions annotations by writing workflow commands to standard output:

```text
::warning file=<file path>,line=<line>::<message>
```

`GitHubAnnotationsReporter` previously interpolated the relative file path without escaping it, while escaping only line feeds in the message. GitHub defines different escaping rules for these contexts. Command data must escape `%`, carriage returns, and line feeds. Command properties must also escape `:` and `,`, which delimit the command and its properties. Without this encoding, a specially crafted path can alter an annotation's structure. If a raw line break reaches the reporter unchanged, it can also terminate the annotation and cause the following text to resemble another workflow command:

```text
src/example.php
::error file=README.md,line=1,title=Injected::Attacker-controlled annotation.php
```

This PR encodes the file path as command-property data and the annotation message as command data. The implementation references GitHub's workflow-command documentation and a pinned version of the official Actions toolkit, which defines the exact character sets.

## Potential abuse

If an attacker can inject a complete workflow command through a raw line break, the most disruptive candidate is `stop-commands`:

```text
::stop-commands::ATTACKER_TOKEN
```

The runner stops interpreting subsequent workflow commands until it encounters the matching resume marker:

```text
::ATTACKER_TOKEN::
```

This could prevent the creation of later Infection annotations or annotations from other tools in the same step. The underlying output would remain in the raw job log, so this would suppress structured annotations without deleting the evidence.

The same precondition could permit an `add-mask` command:

```text
::add-mask::attacker-chosen text
```

GitHub replaces subsequent occurrences of the selected text in the job log with `***`. This cannot reveal secrets, but it could obscure filenames, error messages, test names, or other diagnostic text.

Annotation and presentation commands could also fabricate or distort review feedback:

```text
::error file=trusted.php,line=10,title=Security failure::Fabricated finding
::warning file=src/Foo.php,line=20::Misleading warning
::notice::Fake success or review instruction
::group::Misleading section
::endgroup::
```

These are consequences of a successful workflow-command injection rather than independently reproduced exploit paths. They could attribute findings to innocent code, impersonate another analyser, or flood the checks interface. An `error` annotation does not itself cause a step to fail.

## Security impact

The confirmed defect allows reserved characters in repository-controlled values to alter the grammar of a generated annotation. The plausible impact is therefore a loss of integrity in CI reporting through malformed or false annotations, masked diagnostic output, or suppressed later annotations. No route from this defect to secret disclosure, repository writes, arbitrary command execution, or a changed job result has been demonstrated.

Historically, stdout commands such as `set-env` and `add-path` presented a greater risk because they could influence later process execution. GitHub disabled those commands and replaced them with environment files. The old `set-output` stdout command is also deprecated, so these are not treated as viable impacts on a current GitHub-hosted runner.

For these reasons, this is treated as a security-hardening fix rather than grounds for requesting a CVE. This assessment should be revisited if an affected downstream configuration demonstrates that the defect crosses a security boundary or affects a protected decision.

## Changes

Escapes the affected annotation values.
