### PR TITLE
refactor(reporter): Refactor GitHub annotation command formatting

### DIFF
--- a/src/Reporter/GitHubAnnotationsReporter.php
+++ b/src/Reporter/GitHubAnnotationsReporter.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Reporter;
 
+use function array_map;
 use Infection\Metrics\ResultsCollector;
+use Infection\Mutant\MutantExecutionResult;
 use function sprintf;
 use function str_replace;
 use Symfony\Component\Filesystem\Path;
@@ -55,32 +57,33 @@ final readonly class GitHubAnnotationsReporter implements LineMutationTestingRes
 
     public function getLines(): array
     {
-        $lines = [];
-
-        foreach ($this->resultsCollector->getEscapedExecutionResults() as $escapedExecutionResult) {
-            $error = [
-                'line' => $escapedExecutionResult->getOriginalStartingLine(),
-                'message' => <<<"TEXT"
-                    Escaped Mutant for Mutator "{$escapedExecutionResult->getMutatorName()}":
-
-                    {$escapedExecutionResult->getMutantDiff()}
-                    TEXT,
-            ];
-
-            $lines[] = $this->buildAnnotation(
-                Path::makeRelative($escapedExecutionResult->getOriginalFilePath(), $this->projectDirectory),
-                $error,
-            );
-        }
-
-        return $lines;
+        return array_map(
+            $this->mapToAnnotation(...),
+            $this->resultsCollector->getEscapedExecutionResults(),
+        );
     }
 
-    /**
-     * @param array{line: int, message: string} $error
-     */
-    private function buildAnnotation(string $filePath, array $error): string
+    private function mapToAnnotation(MutantExecutionResult $result): string
     {
+        return self::buildAnnotation(
+            Path::makeRelative(
+                $result->getOriginalFilePath(),
+                $this->projectDirectory,
+            ),
+            $result->getOriginalStartingLine(),
+            <<<TEXT
+                Escaped Mutant for Mutator "{$result->getMutatorName()}":
+
+                {$result->getMutantDiff()}
+                TEXT,
+        );
+    }
+
+    private static function buildAnnotation(
+        string $filePath,
+        int $line,
+        string $message,
+    ): string {
         // Data and properties need to be escaped to avoid a file path or error message to hijack
         // the GitHub annotations by leveraging the annotation delimiters.
         //
@@ -88,19 +91,21 @@ final readonly class GitHubAnnotationsReporter implements LineMutationTestingRes
         // https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#about-workflow-commands
         // https://github.com/actions/toolkit/blob/193fa46c20fde8b0ed54194bc08b841c78c0776d/packages/core/src/command.ts#L92-L111
         return sprintf(
+            // The format is:
+            // ::workflow-command parameter1={data},parameter2={data}::{command value}
             "::warning file=%s,line=%d::%s\n",
-            self::escapeProperty($filePath),
-            $error['line'],
-            self::escapeData($error['message']),
+            self::escapeParameterValue($filePath),
+            $line,
+            self::escapeCommandValue($message),
         );
     }
 
-    private static function escapeData(string $value): string
+    private static function escapeCommandValue(string $value): string
     {
         return str_replace(['%', "\r", "\n"], ['%25', '%0D', '%0A'], $value);
     }
 
-    private static function escapeProperty(string $value): string
+    private static function escapeParameterValue(string $value): string
     {
         return str_replace(['%', "\r", "\n", ':', ','], ['%25', '%0D', '%0A', '%3A', '%2C'], $value);
     }


### PR DESCRIPTION
## Description

Clarify how escaped mutant results are converted into GitHub Actions warning annotations. The refactor aligns the helper names with GitHub's documented workflow-command terminology while preserving the existing escaping behaviour.

This PR is a follow up of https://github.com/infection/infection/pull/3441#discussion_r3730021979.

## Changes

- Maps escaped mutant execution results directly to annotation lines to make the code a bit more succinct.
- Passes the annotation line and message as explicit values instead of an intermediate array shape to be more explicit and reduce noise (the intermediate shape is more confusing and requires more phpdoc).
- Renames the escaping helpers to distinguish workflow-command parameter values from command values rather than using the internal `actions/toolkit` terminology as the former is the officially communicated terminology.
- Documents the GitHub workflow-command format next to the generated annotation for good measure.
