### PR TITLE
fix(phpunit): Use recordTestRunHistory instead of cacheResult on PHPUnit 13.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,7 +363,7 @@ Memory is released by `unset()` of the container reference before freeing the sl
 
 `XmlConfigurationManipulator` is ~15 small public methods, one edit each, composed by two
 builders; the
-`version_compare` cutoffs (5.2, 7.2, 7.3, 9.3, 10, 10.1, 11.0, 12.0) each have a comment
+`version_compare` cutoffs (5.2, 7.2, 7.3, 9.3, 10, 10.1, 11.0, 12.0, 13.3) each have a comment
 linking the phpunit.xsd change - keep them. Hard rules: PHPUnit >= 12's coverage/`<source>`
 config is authoritative - leave it untouched (#3043 regression); when the user has an
 include filter and no source filtering is requested, preserve their config rather than

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -12863,6 +12863,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_disables_caching_for_phpunit_13_3`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_disables_caching`.'
 count = 1
 

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -12773,6 +12773,12 @@ count = 1
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "imprecise-type"
+message = "Type `iterable` in return type of `executionOrderValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "imprecise-type"
 message = "Type `iterable` in return type of `failOnProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
@@ -12780,13 +12786,13 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "non-existent-property"
 message = "Property `$value` does not exist on class `DOMNameSpaceNode`."
-count = 3
+count = 4
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "non-existent-property"
 message = "Property `$value` does not exist on class `DOMNode`."
-count = 3
+count = 4
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
@@ -12810,6 +12816,12 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_adds_fail_on_risky_and_warning_for_proper_phpunit_versions`.'
+count = 1
+
+[[issues]]
+file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_adds_the_execution_order_supported_by_the_phpunit_version`.'
 count = 1
 
 [[issues]]

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -213,6 +213,11 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
 
     public static function supportsExecutionOrderDefectsRandom(string $version): bool
     {
+        // ordering by defects needs the test run history, which the initial run deactivates. PHPUnit ignored that combination silently until 13.3 turned it into a warning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
+        if (version_compare($version, '13.3', '>=')) {
+            return false;
+        }
+
         return
             version_compare($version, '10.5.48', '>=') && version_compare($version, '11.0', '<')
             || version_compare($version, '11.5.27', '>=') && version_compare($version, '12.0', '<')

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -90,7 +90,7 @@ final readonly class InitialConfigBuilder implements ConfigBuilder
         $this->configManipulator->replaceWithAbsolutePaths($xPath);
         $this->configManipulator->setStopOnFailureOrDefect($version, $xPath);
         $this->configManipulator->deactivateColours($xPath);
-        $this->configManipulator->deactivateResultCaching($xPath);
+        $this->configManipulator->deactivateResultCaching($version, $xPath);
         $this->configManipulator->deactivateStderrRedirection($xPath);
         $this->configManipulator->removeExistingLoggers($xPath);
         $this->configManipulator->removeExistingPrinters($xPath);

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -156,8 +156,7 @@ final readonly class InitialConfigBuilder implements ConfigBuilder
 
     private function addRandomTestsOrderAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void
     {
-        // ordering by defects needs the test run history, which the initial run deactivates. PHPUnit ignored that combination silently until 13.3 turned it into a warning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
-        if (PhpUnitAdapter::supportsExecutionOrderDefectsRandom($version) && version_compare($version, '13.3', '<')) {
+        if (PhpUnitAdapter::supportsExecutionOrderDefectsRandom($version)) {
             if ($this->addAttributeIfNotSet('executionOrder', 'defects,random', $xPath)) {
                 $this->addAttributeIfNotSet('resolveDependencies', 'true', $xPath);
             }

--- a/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
+++ b/src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php
@@ -156,7 +156,8 @@ final readonly class InitialConfigBuilder implements ConfigBuilder
 
     private function addRandomTestsOrderAttributesIfNotSet(string $version, SafeDOMXPath $xPath): void
     {
-        if (PhpUnitAdapter::supportsExecutionOrderDefectsRandom($version)) {
+        // ordering by defects needs the test run history, which the initial run deactivates. PHPUnit ignored that combination silently until 13.3 turned it into a warning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
+        if (PhpUnitAdapter::supportsExecutionOrderDefectsRandom($version) && version_compare($version, '13.3', '<')) {
             if ($this->addAttributeIfNotSet('executionOrder', 'defects,random', $xPath)) {
                 $this->addAttributeIfNotSet('resolveDependencies', 'true', $xPath);
             }

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -95,13 +95,29 @@ final readonly class XmlConfigurationManipulator
         }
     }
 
-    public function deactivateResultCaching(SafeDOMXPath $xPath): void
+    public function deactivateResultCaching(string $version, SafeDOMXPath $xPath): void
     {
+        // starting from PHPUnit 13.3 cacheResult is deprecated in favour of recordTestRunHistory, and using it makes PHPUnit report a test runner deprecation https://github.com/sebastianbergmann/phpunit/blob/13.3.0/phpunit.xsd
+        if (version_compare($version, '13.3', '>=')) {
+            $this->setAttributeValue($xPath, 'recordTestRunHistory', 'false');
+
+            return;
+        }
+
         $this->setAttributeValue($xPath, 'cacheResult', 'false');
     }
 
     public function handleResultCacheAndExecutionOrder(string $version, SafeDOMXPath $xPath, string $mutationHash, string $tmpDir): void
     {
+        // starting from PHPUnit 13.3 cacheResult is deprecated in favour of recordTestRunHistory https://github.com/sebastianbergmann/phpunit/blob/13.3.0/phpunit.xsd
+        if (version_compare($version, '13.3', '>=')) {
+            $this->setAttributeValue($xPath, 'recordTestRunHistory', 'true');
+            $this->setAttributeValue($xPath, 'cacheDirectory', sprintf('%s/.phpunit.result.cache.%s', $tmpDir, $mutationHash));
+            $this->setAttributeValue($xPath, 'executionOrder', 'defects');
+
+            return;
+        }
+
         // starting from PHPUnit 11.0 the cacheResultFile was removed, we now set cacheDirectory instead https://github.com/sebastianbergmann/phpunit/blob/11.0.0/phpunit.xsd
         if (version_compare($version, '11.0', '>=')) {
             $this->setAttributeValue($xPath, 'cacheResult', 'true');

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -97,7 +97,7 @@ final readonly class XmlConfigurationManipulator
 
     public function deactivateResultCaching(string $version, SafeDOMXPath $xPath): void
     {
-        // starting from PHPUnit 13.3 cacheResult is deprecated in favour of recordTestRunHistory, and using it makes PHPUnit report a test runner deprecation https://github.com/sebastianbergmann/phpunit/blob/13.3.0/phpunit.xsd
+        // PHPUnit 13.3 deprecated cacheResult in favour of recordTestRunHistory
         if (version_compare($version, '13.3', '>=')) {
             $this->setAttributeValue($xPath, 'recordTestRunHistory', 'false');
 
@@ -109,7 +109,7 @@ final readonly class XmlConfigurationManipulator
 
     public function handleResultCacheAndExecutionOrder(string $version, SafeDOMXPath $xPath, string $mutationHash, string $tmpDir): void
     {
-        // starting from PHPUnit 13.3 cacheResult is deprecated in favour of recordTestRunHistory https://github.com/sebastianbergmann/phpunit/blob/13.3.0/phpunit.xsd
+        // PHPUnit 13.3 deprecated cacheResult in favour of recordTestRunHistory
         if (version_compare($version, '13.3', '>=')) {
             $this->setAttributeValue($xPath, 'recordTestRunHistory', 'true');
             $this->setAttributeValue($xPath, 'cacheDirectory', sprintf('%s/.phpunit.result.cache.%s', $tmpDir, $mutationHash));

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -98,29 +98,19 @@ final readonly class XmlConfigurationManipulator
     public function deactivateResultCaching(string $version, SafeDOMXPath $xPath): void
     {
         // PHPUnit 13.3 deprecated cacheResult in favour of recordTestRunHistory
-        if (version_compare($version, '13.3', '>=')) {
-            $this->setAttributeValue($xPath, 'recordTestRunHistory', 'false');
+        $attribute = version_compare($version, '13.3', '>=') ? 'recordTestRunHistory' : 'cacheResult';
 
-            return;
-        }
-
-        $this->setAttributeValue($xPath, 'cacheResult', 'false');
+        $this->setAttributeValue($xPath, $attribute, 'false');
     }
 
     public function handleResultCacheAndExecutionOrder(string $version, SafeDOMXPath $xPath, string $mutationHash, string $tmpDir): void
     {
-        // PHPUnit 13.3 deprecated cacheResult in favour of recordTestRunHistory
-        if (version_compare($version, '13.3', '>=')) {
-            $this->setAttributeValue($xPath, 'recordTestRunHistory', 'true');
-            $this->setAttributeValue($xPath, 'cacheDirectory', sprintf('%s/.phpunit.result.cache.%s', $tmpDir, $mutationHash));
-            $this->setAttributeValue($xPath, 'executionOrder', 'defects');
-
-            return;
-        }
-
         // starting from PHPUnit 11.0 the cacheResultFile was removed, we now set cacheDirectory instead https://github.com/sebastianbergmann/phpunit/blob/11.0.0/phpunit.xsd
         if (version_compare($version, '11.0', '>=')) {
-            $this->setAttributeValue($xPath, 'cacheResult', 'true');
+            // PHPUnit 13.3 deprecated cacheResult in favour of recordTestRunHistory
+            $attribute = version_compare($version, '13.3', '>=') ? 'recordTestRunHistory' : 'cacheResult';
+
+            $this->setAttributeValue($xPath, $attribute, 'true');
             $this->setAttributeValue($xPath, 'cacheDirectory', sprintf('%s/.phpunit.result.cache.%s', $tmpDir, $mutationHash));
             $this->setAttributeValue($xPath, 'executionOrder', 'defects');
 

--- a/tests/e2e/PHPUnit_13-2/.gitignore
+++ b/tests/e2e/PHPUnit_13-2/.gitignore
@@ -1,0 +1,4 @@
+!/var/.gitkeep
+/composer.lock
+/var/
+/vendor/

--- a/tests/e2e/PHPUnit_13-2/Makefile
+++ b/tests/e2e/PHPUnit_13-2/Makefile
@@ -1,0 +1,48 @@
+SHELL=bash
+.DEFAULT_GOAL := help
+
+# See https://tech.davis-hansson.com/p/make/
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+
+PHPUNIT_BIN = vendor/bin/phpunit
+PHPUNIT_COVERAGE_DIR = var/coverage
+PHPUNIT_COVERAGE_XML_DIR = $(PHPUNIT_COVERAGE_DIR)/xml
+PHPUNIT_COVERAGE_JUNIT = $(PHPUNIT_COVERAGE_DIR)/junit.xml
+
+
+.PHONY: help
+help:
+	@printf "\033[33mUsage:\033[0m\n  make TARGET\n\n\033[32m#\n# Commands\n#---------------------------------------------------------------------------\033[0m\n\n"
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | awk 'BEGIN {FS = ":"}; {printf "\033[33m%s:\033[0m%s\n", $$1, $$2}'
+
+
+.PHONY: cs
+cs: ## Fix the ordering of the .gitignore entries
+cs:
+	LC_ALL=C sort -u .gitignore -o .gitignore
+
+
+.PHONY: test
+test: ## Execute the tests
+test: $(PHPUNIT_BIN)
+	$(PHPUNIT_BIN)
+
+
+.PHONY: phpunit-coverage
+phpunit-coverage: ## Generate coverage
+phpunit-coverage: $(PHPUNIT_BIN)
+	rm -rf $(PHPUNIT_COVERAGE_XML_DIR) || true
+	XDEBUG_MODE=coverage $(PHPUNIT_BIN) --coverage-xml=$(PHPUNIT_COVERAGE_XML_DIR) --log-junit=$(PHPUNIT_COVERAGE_JUNIT)
+
+
+$(PHPUNIT_BIN): vendor
+
+vendor: composer.lock
+
+composer.lock: composer.json
+	composer update --prefer-dist
+	touch -c vendor
+	touch -c composer.lock
+	touch -c composer.json

--- a/tests/e2e/PHPUnit_13-2/README.md
+++ b/tests/e2e/PHPUnit_13-2/README.md
@@ -1,0 +1,14 @@
+## Summary
+
+The goal of this test is to ensure Infection works with PHPUnit 13 below 13.3, where the
+generated configuration still uses the `cacheResult` attribute.
+
+This project test contains:
+
+- A class `Calculator`.
+- A trait `LoggerTrait`.
+- A class using a trait `UserService`.
+- All of are present in two directories, a version covered in
+  `src/Covered` and uncovered in `src/Uncovered`.
+
+The coverage data can be generated with `make phpunit-coverage`.

--- a/tests/e2e/PHPUnit_13-2/composer.json
+++ b/tests/e2e/PHPUnit_13-2/composer.json
@@ -1,0 +1,25 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^13"
+    },
+    "conflict": {
+        "phpunit/phpunit": ">=13.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "Infection\\E2ETests\\PHPUnit_13_2\\": "src/"
+        },
+        "files": [
+            "src/Covered/functions.php",
+            "src/Uncovered/functions.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Infection\\E2ETests\\PHPUnit_13_2\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/expected-output.txt
+++ b/tests/e2e/PHPUnit_13-2/expected-output.txt
@@ -1,0 +1,11 @@
+Total: 46
+
+Killed by Test Framework: 45
+Killed by Static Analysis: 0
+Errored: 0
+Syntax Errors: 0
+Escaped: 1
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/PHPUnit_13-2/infection.json5
+++ b/tests/e2e/PHPUnit_13-2/infection.json5
@@ -1,0 +1,14 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "threads": 1,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "var/infection.log"
+    },
+    "tmpDir": "var/infection-tmp"
+}

--- a/tests/e2e/PHPUnit_13-2/phpunit.xml
+++ b/tests/e2e/PHPUnit_13-2/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         testdoxSummary="true"
+         cacheDirectory="var/phpunit-cache"
+         failOnPhpunitDeprecation="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/e2e/PHPUnit_13-2/run_tests.bash
+++ b/tests/e2e/PHPUnit_13-2/run_tests.bash
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
+if [ $(php -r 'echo version_compare(PHP_VERSION, "8.4.1", "<");') ]; then
+    echo "Skipping test it needs PHP 8.4.1 or higher (found $(php -r 'echo PHP_VERSION;'))"
+    exit 0
+fi
+
+readonly INFECTION=../../../${1}
+
+set -eo pipefail
+
+if [ "$DRIVER" = "phpdbg" ]
+then
+    phpdbg -qrr $INFECTION
+else
+    php $INFECTION
+fi
+
+if [ -f "var/infection.log" ]; then
+    LOG_FILE="var/infection.log"
+else
+    LOG_FILE="infection.log"
+fi
+
+if [ -n "$GOLDEN" ]; then
+    cp -v "$LOG_FILE" expected-output.txt
+fi
+
+diff -u --ignore-all-space expected-output.txt "$LOG_FILE"

--- a/tests/e2e/PHPUnit_13-2/src/Covered/Calculator.php
+++ b/tests/e2e/PHPUnit_13-2/src/Covered/Calculator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Covered;
+
+class Calculator
+{
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+
+    public function subtract(int $a, int $b): int
+    {
+        return $a - $b;
+    }
+
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+
+    public function divide(int $a, int $b): float
+    {
+        if ($b === 0) {
+            throw new \InvalidArgumentException('Division by zero');
+        }
+
+        return $a / $b;
+    }
+
+    public function isPositive(int $number): bool
+    {
+        return $number >= 0;
+    }
+
+    public function absolute(int $number): int
+    {
+        return $number <= 0 ? -$number : $number;
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/src/Covered/LoggerTrait.php
+++ b/tests/e2e/PHPUnit_13-2/src/Covered/LoggerTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Covered;
+
+trait LoggerTrait
+{
+    private array $logs = [];
+
+    public function log(string $message): void
+    {
+        $this->logs[] = $message;
+    }
+
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+
+    public function clearLogs(): void
+    {
+        $this->logs = [];
+    }
+
+    public function hasLogs(): bool
+    {
+        return count($this->logs) > 0;
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/src/Covered/UserService.php
+++ b/tests/e2e/PHPUnit_13-2/src/Covered/UserService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Covered;
+
+class UserService
+{
+    use LoggerTrait;
+
+    private array $users = [];
+
+    public function addUser(string $name, string $email): bool
+    {
+        if (empty($name) || empty($email)) {
+            $this->log('Failed to add user: empty name or email');
+            return false;
+        }
+
+        if ($this->userExists($email)) {
+            $this->log("Failed to add user: email {$email} already exists");
+            return false;
+        }
+
+        $this->users[$email] = ['name' => $name, 'email' => $email];
+        $this->log("User {$name} added successfully");
+        return true;
+    }
+
+    public function removeUser(string $email): bool
+    {
+        if (!$this->userExists($email)) {
+            $this->log("Failed to remove user: email {$email} not found");
+            return false;
+        }
+
+        unset($this->users[$email]);
+        $this->log("User {$email} removed successfully");
+        return true;
+    }
+
+    public function getUser(string $email): ?array
+    {
+        return $this->users[$email] ?? null;
+    }
+
+    public function userExists(string $email): bool
+    {
+        return isset($this->users[$email]);
+    }
+
+    public function getUserCount(): int
+    {
+        return count($this->users);
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/src/Covered/functions.php
+++ b/tests/e2e/PHPUnit_13-2/src/Covered/functions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Covered;
+
+function formatName(string $firstName, string $lastName): string
+{
+    if (empty($firstName) && empty($lastName)) {
+        return 'Anonymous';
+    }
+
+    if (empty($firstName)) {
+        return $lastName;
+    }
+
+    if (empty($lastName)) {
+        return $firstName;
+    }
+
+    return "{$firstName} {$lastName}";
+}

--- a/tests/e2e/PHPUnit_13-2/src/Uncovered/Calculator.php
+++ b/tests/e2e/PHPUnit_13-2/src/Uncovered/Calculator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Uncovered;
+
+class Calculator
+{
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+
+    public function subtract(int $a, int $b): int
+    {
+        return $a - $b;
+    }
+
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+
+    public function divide(int $a, int $b): float
+    {
+        if ($b === 0) {
+            throw new \InvalidArgumentException('Division by zero');
+        }
+
+        return $a / $b;
+    }
+
+    public function isPositive(int $number): bool
+    {
+        return $number > 0;
+    }
+
+    public function absolute(int $number): int
+    {
+        return $number < 0 ? -$number : $number;
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/src/Uncovered/LoggerTrait.php
+++ b/tests/e2e/PHPUnit_13-2/src/Uncovered/LoggerTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Uncovered;
+
+trait LoggerTrait
+{
+    private array $logs = [];
+
+    public function log(string $message): void
+    {
+        $this->logs[] = $message;
+    }
+
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+
+    public function clearLogs(): void
+    {
+        $this->logs = [];
+    }
+
+    public function hasLogs(): bool
+    {
+        return count($this->logs) > 0;
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/src/Uncovered/UserService.php
+++ b/tests/e2e/PHPUnit_13-2/src/Uncovered/UserService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Uncovered;
+
+class UserService
+{
+    use LoggerTrait;
+
+    private array $users = [];
+
+    public function addUser(string $name, string $email): bool
+    {
+        if (empty($name) || empty($email)) {
+            $this->log('Failed to add user: empty name or email');
+            return false;
+        }
+
+        if ($this->userExists($email)) {
+            $this->log("Failed to add user: email {$email} already exists");
+            return false;
+        }
+
+        $this->users[$email] = ['name' => $name, 'email' => $email];
+        $this->log("User {$name} added successfully");
+        return true;
+    }
+
+    public function removeUser(string $email): bool
+    {
+        if (!$this->userExists($email)) {
+            $this->log("Failed to remove user: email {$email} not found");
+            return false;
+        }
+
+        unset($this->users[$email]);
+        $this->log("User {$email} removed successfully");
+        return true;
+    }
+
+    public function getUser(string $email): ?array
+    {
+        return $this->users[$email] ?? null;
+    }
+
+    public function userExists(string $email): bool
+    {
+        return isset($this->users[$email]);
+    }
+
+    public function getUserCount(): int
+    {
+        return count($this->users);
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/src/Uncovered/functions.php
+++ b/tests/e2e/PHPUnit_13-2/src/Uncovered/functions.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Uncovered;
+
+function formatName(string $firstName, string $lastName): string
+{
+    if (empty($firstName) && empty($lastName)) {
+        return 'Anonymous';
+    }
+
+    if (empty($firstName)) {
+        return $lastName;
+    }
+
+    if (empty($lastName)) {
+        return $firstName;
+    }
+
+    return "{$firstName} {$lastName}";
+}
+
+function calculateDiscount(float $price, int $discountPercent): float
+{
+    if ($discountPercent < 0 || $discountPercent > 100) {
+        throw new \InvalidArgumentException('Discount must be between 0 and 100');
+    }
+
+    if ($price <= 0) {
+        return 0.0;
+    }
+
+    $discount = ($price * $discountPercent) / 100;
+    return $price - $discount;
+}
+
+function isValidEmail(string $email): bool
+{
+    if (empty($email)) {
+        return false;
+    }
+
+    return str_contains($email, '@') && str_contains($email, '.');
+}

--- a/tests/e2e/PHPUnit_13-2/tests/Covered/CalculatorProvider.php
+++ b/tests/e2e/PHPUnit_13-2/tests/Covered/CalculatorProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Tests\Covered;
+
+final class CalculatorProvider
+{
+    public static function provideAdditions(): iterable
+    {
+        yield [2, 3, 5];
+        yield [-5, 5, 0];
+        yield [-5, -5, -10];
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/tests/Covered/CalculatorTest.php
+++ b/tests/e2e/PHPUnit_13-2/tests/Covered/CalculatorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Tests\Covered;
+
+use Infection\E2ETests\PHPUnit_13_2\Covered\Calculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Calculator::class)]
+class CalculatorTest extends TestCase
+{
+    private Calculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new Calculator();
+    }
+
+    #[DataProviderExternal(CalculatorProvider::class, 'provideAdditions')]
+    public function test_add(int $a, int $b, int $expected): void
+    {
+        $this->assertSame($expected, $this->calculator->add($a, $b));
+    }
+
+    #[DataProvider('provideSubstractions')]
+    public function test_subtract(int $a, int $b, int $expected): void
+    {
+        $this->assertSame($expected, $this->calculator->subtract($a, $b));
+    }
+
+    public static function provideSubstractions(): iterable
+    {
+        yield [5, 3, 2];
+        yield [5, -5, 10];
+        yield [5, 5, 0];
+    }
+
+    public function test_multiply(): void
+    {
+        $this->assertSame(15, $this->calculator->multiply(3, 5));
+        $this->assertSame(-15, $this->calculator->multiply(-3, 5));
+        $this->assertSame(0, $this->calculator->multiply(0, 5));
+    }
+
+    public function test_divide(): void
+    {
+        $this->assertSame(2.5, $this->calculator->divide(5, 2));
+        $this->assertSame(-2.5, $this->calculator->divide(-5, 2));
+        $this->assertSame(1.0, $this->calculator->divide(5, 5));
+    }
+
+    public function test_divide_by_zero_throws_exception(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Division by zero');
+        $this->calculator->divide(5, 0);
+    }
+
+    public function test_is_positive(): void
+    {
+        $this->assertTrue($this->calculator->isPositive(5));
+        $this->assertFalse($this->calculator->isPositive(-5));
+        $this->assertTrue($this->calculator->isPositive(0));
+    }
+
+    public function test_absolute(): void
+    {
+        $this->assertSame(5, $this->calculator->absolute(5));
+        $this->assertSame(5, $this->calculator->absolute(-5));
+    }
+
+    public function test_absolute_zero(): void
+    {
+        // Test edge case: 0 should not be negated (0 is not less than 0)
+        $result = $this->calculator->absolute(0);
+        $this->assertSame(0, $result);
+
+        // Test boundary values - ensure the comparison is strictly less than, not less than or equal
+        $this->assertSame(1, $this->calculator->absolute(1));
+        $this->assertSame(1, $this->calculator->absolute(-1));
+
+        // Verify that 0 behaves the same as positive numbers (returned as-is)
+        // If the mutant changes < to <=, it would negate 0, but -0 === 0 in PHP
+        // This mutant is technically equivalent and cannot be caught
+        $this->assertTrue($result === 0);
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/tests/Covered/FunctionsTest.php
+++ b/tests/e2e/PHPUnit_13-2/tests/Covered/FunctionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Tests\Covered;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+use function Infection\E2ETests\PHPUnit_13_2\Covered\formatName;
+
+#[CoversFunction('Infection\E2ETests\PHPUnit_13_2\Covered\formatName')]
+class FunctionsTest extends TestCase
+{
+    public function test_format_name_with_both_names(): void
+    {
+        $this->assertSame('John Doe', formatName('John', 'Doe'));
+    }
+
+    public function test_format_name_with_first_name_only(): void
+    {
+        $this->assertSame('John', formatName('John', ''));
+    }
+
+    public function test_format_name_with_last_name_only(): void
+    {
+        $this->assertSame('Doe', formatName('', 'Doe'));
+    }
+
+    public function test_format_name_with_no_names(): void
+    {
+        $this->assertSame('Anonymous', formatName('', ''));
+    }
+}

--- a/tests/e2e/PHPUnit_13-2/tests/Covered/UserServiceTest.php
+++ b/tests/e2e/PHPUnit_13-2/tests/Covered/UserServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_2\Tests\Covered;
+
+use Infection\E2ETests\PHPUnit_13_2\Covered\LoggerTrait;
+use Infection\E2ETests\PHPUnit_13_2\Covered\UserService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+
+#[CoversTrait(LoggerTrait::class)]
+#[CoversClass(UserService::class)]
+class UserServiceTest extends TestCase
+{
+    private UserService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new UserService();
+    }
+
+    public function test_add_user_successfully(): void
+    {
+        $result = $this->service->addUser('John Doe', 'john@example.com');
+
+        $this->assertTrue($result);
+        $this->assertSame(1, $this->service->getUserCount());
+        $this->assertTrue($this->service->hasLogs());
+    }
+
+    public function test_add_user_with_empty_name_fails(): void
+    {
+        $result = $this->service->addUser('', 'john@example.com');
+
+        $this->assertFalse($result);
+        $this->assertSame(0, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to add user: empty name or email', $logs[0]);
+    }
+
+    public function test_add_user_with_empty_email_fails(): void
+    {
+        $result = $this->service->addUser('John Doe', '');
+
+        $this->assertFalse($result);
+        $this->assertSame(0, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to add user: empty name or email', $logs[0]);
+    }
+
+    public function test_add_duplicate_user_fails(): void
+    {
+        $this->service->addUser('John Doe', 'john@example.com');
+        $this->service->clearLogs();
+
+        $result = $this->service->addUser('Jane Doe', 'john@example.com');
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to add user: email john@example.com already exists', $logs[0]);
+    }
+
+    public function test_remove_user_successfully(): void
+    {
+        $this->service->addUser('John Doe', 'john@example.com');
+        $this->service->clearLogs();
+
+        $result = $this->service->removeUser('john@example.com');
+
+        $this->assertTrue($result);
+        $this->assertSame(0, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('User john@example.com removed successfully', $logs[0]);
+    }
+
+    public function test_remove_non_existent_user_fails(): void
+    {
+        $result = $this->service->removeUser('john@example.com');
+
+        $this->assertFalse($result);
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to remove user: email john@example.com not found', $logs[0]);
+    }
+
+    public function test_get_user_returns_user_data(): void
+    {
+        $this->service->addUser('John Doe', 'john@example.com');
+        $user = $this->service->getUser('john@example.com');
+
+        $this->assertIsArray($user);
+        $this->assertSame('John Doe', $user['name']);
+        $this->assertSame('john@example.com', $user['email']);
+    }
+
+    public function test_get_user_returns_null_for_non_existent_user(): void
+    {
+        $user = $this->service->getUser('john@example.com');
+
+        $this->assertNull($user);
+    }
+
+    public function test_user_exists(): void
+    {
+        $this->assertFalse($this->service->userExists('john@example.com'));
+
+        $this->service->addUser('John Doe', 'john@example.com');
+
+        $this->assertTrue($this->service->userExists('john@example.com'));
+    }
+
+    public function test_logger_trait_methods(): void
+    {
+        $this->assertFalse($this->service->hasLogs());
+        $this->assertEmpty($this->service->getLogs());
+
+        $this->service->addUser('John Doe', 'john@example.com');
+
+        $this->assertTrue($this->service->hasLogs());
+        $this->assertNotEmpty($this->service->getLogs());
+
+        $this->service->clearLogs();
+
+        $this->assertFalse($this->service->hasLogs());
+        $this->assertEmpty($this->service->getLogs());
+    }
+
+    public function test_log_method_is_public(): void
+    {
+        // Test that log() method can be called from outside the class
+        // If it's protected, this will cause a fatal error
+        $reflection = new \ReflectionMethod(UserService::class, 'log');
+        $this->assertTrue($reflection->isPublic(), 'log() method must be public');
+
+        // Also test we can actually call it
+        $this->service->log('Direct log call');
+        $logs = $this->service->getLogs();
+        $this->assertContains('Direct log call', $logs);
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/.gitignore
+++ b/tests/e2e/PHPUnit_13-3/.gitignore
@@ -1,0 +1,4 @@
+!/var/.gitkeep
+/composer.lock
+/var/
+/vendor/

--- a/tests/e2e/PHPUnit_13-3/Makefile
+++ b/tests/e2e/PHPUnit_13-3/Makefile
@@ -1,0 +1,48 @@
+SHELL=bash
+.DEFAULT_GOAL := help
+
+# See https://tech.davis-hansson.com/p/make/
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+
+PHPUNIT_BIN = vendor/bin/phpunit
+PHPUNIT_COVERAGE_DIR = var/coverage
+PHPUNIT_COVERAGE_XML_DIR = $(PHPUNIT_COVERAGE_DIR)/xml
+PHPUNIT_COVERAGE_JUNIT = $(PHPUNIT_COVERAGE_DIR)/junit.xml
+
+
+.PHONY: help
+help:
+	@printf "\033[33mUsage:\033[0m\n  make TARGET\n\n\033[32m#\n# Commands\n#---------------------------------------------------------------------------\033[0m\n\n"
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | awk 'BEGIN {FS = ":"}; {printf "\033[33m%s:\033[0m%s\n", $$1, $$2}'
+
+
+.PHONY: cs
+cs: ## Fix the ordering of the .gitignore entries
+cs:
+	LC_ALL=C sort -u .gitignore -o .gitignore
+
+
+.PHONY: test
+test: ## Execute the tests
+test: $(PHPUNIT_BIN)
+	$(PHPUNIT_BIN)
+
+
+.PHONY: phpunit-coverage
+phpunit-coverage: ## Generate coverage
+phpunit-coverage: $(PHPUNIT_BIN)
+	rm -rf $(PHPUNIT_COVERAGE_XML_DIR) || true
+	XDEBUG_MODE=coverage $(PHPUNIT_BIN) --coverage-xml=$(PHPUNIT_COVERAGE_XML_DIR) --log-junit=$(PHPUNIT_COVERAGE_JUNIT)
+
+
+$(PHPUNIT_BIN): vendor
+
+vendor: composer.lock
+
+composer.lock: composer.json
+	composer update --prefer-dist
+	touch -c vendor
+	touch -c composer.lock
+	touch -c composer.json

--- a/tests/e2e/PHPUnit_13-3/README.md
+++ b/tests/e2e/PHPUnit_13-3/README.md
@@ -1,0 +1,18 @@
+## Summary
+
+The goal of this test is to ensure Infection works with PHPUnit 13.3+, which deprecated the
+`cacheResult` attribute in favour of `recordTestRunHistory`.
+
+See:
+
+- https://github.com/infection/infection/issues/3445
+
+This project test contains:
+
+- A class `Calculator`.
+- A trait `LoggerTrait`.
+- A class using a trait `UserService`.
+- All of are present in two directories, a version covered in
+  `src/Covered` and uncovered in `src/Uncovered`.
+
+The coverage data can be generated with `make phpunit-coverage`.

--- a/tests/e2e/PHPUnit_13-3/composer.json
+++ b/tests/e2e/PHPUnit_13-3/composer.json
@@ -1,0 +1,22 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^13.3"
+    },
+    "autoload": {
+        "psr-4": {
+            "Infection\\E2ETests\\PHPUnit_13_3\\": "src/"
+        },
+        "files": [
+            "src/Covered/functions.php",
+            "src/Uncovered/functions.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Infection\\E2ETests\\PHPUnit_13_3\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/expected-output.txt
+++ b/tests/e2e/PHPUnit_13-3/expected-output.txt
@@ -1,0 +1,11 @@
+Total: 46
+
+Killed by Test Framework: 45
+Killed by Static Analysis: 0
+Errored: 0
+Syntax Errors: 0
+Escaped: 1
+Timed Out: 0
+Skipped: 0
+Ignored: 0
+Not Covered: 0

--- a/tests/e2e/PHPUnit_13-3/infection.json5
+++ b/tests/e2e/PHPUnit_13-3/infection.json5
@@ -1,0 +1,14 @@
+{
+    "$schema": "../../../resources/schema.json",
+    "timeout": 25,
+    "threads": 1,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "summary": "var/infection.log"
+    },
+    "tmpDir": "var/infection-tmp"
+}

--- a/tests/e2e/PHPUnit_13-3/phpunit.xml
+++ b/tests/e2e/PHPUnit_13-3/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         testdoxSummary="true"
+         cacheDirectory="var/phpunit-cache"
+         failOnPhpunitDeprecation="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tests/e2e/PHPUnit_13-3/run_tests.bash
+++ b/tests/e2e/PHPUnit_13-3/run_tests.bash
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
+if [ $(php -r 'echo version_compare(PHP_VERSION, "8.4.1", "<");') ]; then
+    echo "Skipping test it needs PHP 8.4.1 or higher (found $(php -r 'echo PHP_VERSION;'))"
+    exit 0
+fi
+
+readonly INFECTION=../../../${1}
+
+set -eo pipefail
+
+if [ "$DRIVER" = "phpdbg" ]
+then
+    phpdbg -qrr $INFECTION
+else
+    php $INFECTION
+fi
+
+if [ -f "var/infection.log" ]; then
+    LOG_FILE="var/infection.log"
+else
+    LOG_FILE="infection.log"
+fi
+
+if [ -n "$GOLDEN" ]; then
+    cp -v "$LOG_FILE" expected-output.txt
+fi
+
+diff -u --ignore-all-space expected-output.txt "$LOG_FILE"

--- a/tests/e2e/PHPUnit_13-3/src/Covered/Calculator.php
+++ b/tests/e2e/PHPUnit_13-3/src/Covered/Calculator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Covered;
+
+class Calculator
+{
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+
+    public function subtract(int $a, int $b): int
+    {
+        return $a - $b;
+    }
+
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+
+    public function divide(int $a, int $b): float
+    {
+        if ($b === 0) {
+            throw new \InvalidArgumentException('Division by zero');
+        }
+
+        return $a / $b;
+    }
+
+    public function isPositive(int $number): bool
+    {
+        return $number >= 0;
+    }
+
+    public function absolute(int $number): int
+    {
+        return $number <= 0 ? -$number : $number;
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/src/Covered/LoggerTrait.php
+++ b/tests/e2e/PHPUnit_13-3/src/Covered/LoggerTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Covered;
+
+trait LoggerTrait
+{
+    private array $logs = [];
+
+    public function log(string $message): void
+    {
+        $this->logs[] = $message;
+    }
+
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+
+    public function clearLogs(): void
+    {
+        $this->logs = [];
+    }
+
+    public function hasLogs(): bool
+    {
+        return count($this->logs) > 0;
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/src/Covered/UserService.php
+++ b/tests/e2e/PHPUnit_13-3/src/Covered/UserService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Covered;
+
+class UserService
+{
+    use LoggerTrait;
+
+    private array $users = [];
+
+    public function addUser(string $name, string $email): bool
+    {
+        if (empty($name) || empty($email)) {
+            $this->log('Failed to add user: empty name or email');
+            return false;
+        }
+
+        if ($this->userExists($email)) {
+            $this->log("Failed to add user: email {$email} already exists");
+            return false;
+        }
+
+        $this->users[$email] = ['name' => $name, 'email' => $email];
+        $this->log("User {$name} added successfully");
+        return true;
+    }
+
+    public function removeUser(string $email): bool
+    {
+        if (!$this->userExists($email)) {
+            $this->log("Failed to remove user: email {$email} not found");
+            return false;
+        }
+
+        unset($this->users[$email]);
+        $this->log("User {$email} removed successfully");
+        return true;
+    }
+
+    public function getUser(string $email): ?array
+    {
+        return $this->users[$email] ?? null;
+    }
+
+    public function userExists(string $email): bool
+    {
+        return isset($this->users[$email]);
+    }
+
+    public function getUserCount(): int
+    {
+        return count($this->users);
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/src/Covered/functions.php
+++ b/tests/e2e/PHPUnit_13-3/src/Covered/functions.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Covered;
+
+function formatName(string $firstName, string $lastName): string
+{
+    if (empty($firstName) && empty($lastName)) {
+        return 'Anonymous';
+    }
+
+    if (empty($firstName)) {
+        return $lastName;
+    }
+
+    if (empty($lastName)) {
+        return $firstName;
+    }
+
+    return "{$firstName} {$lastName}";
+}

--- a/tests/e2e/PHPUnit_13-3/src/Uncovered/Calculator.php
+++ b/tests/e2e/PHPUnit_13-3/src/Uncovered/Calculator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Uncovered;
+
+class Calculator
+{
+    public function add(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+
+    public function subtract(int $a, int $b): int
+    {
+        return $a - $b;
+    }
+
+    public function multiply(int $a, int $b): int
+    {
+        return $a * $b;
+    }
+
+    public function divide(int $a, int $b): float
+    {
+        if ($b === 0) {
+            throw new \InvalidArgumentException('Division by zero');
+        }
+
+        return $a / $b;
+    }
+
+    public function isPositive(int $number): bool
+    {
+        return $number > 0;
+    }
+
+    public function absolute(int $number): int
+    {
+        return $number < 0 ? -$number : $number;
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/src/Uncovered/LoggerTrait.php
+++ b/tests/e2e/PHPUnit_13-3/src/Uncovered/LoggerTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Uncovered;
+
+trait LoggerTrait
+{
+    private array $logs = [];
+
+    public function log(string $message): void
+    {
+        $this->logs[] = $message;
+    }
+
+    public function getLogs(): array
+    {
+        return $this->logs;
+    }
+
+    public function clearLogs(): void
+    {
+        $this->logs = [];
+    }
+
+    public function hasLogs(): bool
+    {
+        return count($this->logs) > 0;
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/src/Uncovered/UserService.php
+++ b/tests/e2e/PHPUnit_13-3/src/Uncovered/UserService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Uncovered;
+
+class UserService
+{
+    use LoggerTrait;
+
+    private array $users = [];
+
+    public function addUser(string $name, string $email): bool
+    {
+        if (empty($name) || empty($email)) {
+            $this->log('Failed to add user: empty name or email');
+            return false;
+        }
+
+        if ($this->userExists($email)) {
+            $this->log("Failed to add user: email {$email} already exists");
+            return false;
+        }
+
+        $this->users[$email] = ['name' => $name, 'email' => $email];
+        $this->log("User {$name} added successfully");
+        return true;
+    }
+
+    public function removeUser(string $email): bool
+    {
+        if (!$this->userExists($email)) {
+            $this->log("Failed to remove user: email {$email} not found");
+            return false;
+        }
+
+        unset($this->users[$email]);
+        $this->log("User {$email} removed successfully");
+        return true;
+    }
+
+    public function getUser(string $email): ?array
+    {
+        return $this->users[$email] ?? null;
+    }
+
+    public function userExists(string $email): bool
+    {
+        return isset($this->users[$email]);
+    }
+
+    public function getUserCount(): int
+    {
+        return count($this->users);
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/src/Uncovered/functions.php
+++ b/tests/e2e/PHPUnit_13-3/src/Uncovered/functions.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Uncovered;
+
+function formatName(string $firstName, string $lastName): string
+{
+    if (empty($firstName) && empty($lastName)) {
+        return 'Anonymous';
+    }
+
+    if (empty($firstName)) {
+        return $lastName;
+    }
+
+    if (empty($lastName)) {
+        return $firstName;
+    }
+
+    return "{$firstName} {$lastName}";
+}
+
+function calculateDiscount(float $price, int $discountPercent): float
+{
+    if ($discountPercent < 0 || $discountPercent > 100) {
+        throw new \InvalidArgumentException('Discount must be between 0 and 100');
+    }
+
+    if ($price <= 0) {
+        return 0.0;
+    }
+
+    $discount = ($price * $discountPercent) / 100;
+    return $price - $discount;
+}
+
+function isValidEmail(string $email): bool
+{
+    if (empty($email)) {
+        return false;
+    }
+
+    return str_contains($email, '@') && str_contains($email, '.');
+}

--- a/tests/e2e/PHPUnit_13-3/tests/Covered/CalculatorProvider.php
+++ b/tests/e2e/PHPUnit_13-3/tests/Covered/CalculatorProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Tests\Covered;
+
+final class CalculatorProvider
+{
+    public static function provideAdditions(): iterable
+    {
+        yield [2, 3, 5];
+        yield [-5, 5, 0];
+        yield [-5, -5, -10];
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/tests/Covered/CalculatorTest.php
+++ b/tests/e2e/PHPUnit_13-3/tests/Covered/CalculatorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Tests\Covered;
+
+use Infection\E2ETests\PHPUnit_13_3\Covered\Calculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Calculator::class)]
+class CalculatorTest extends TestCase
+{
+    private Calculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new Calculator();
+    }
+
+    #[DataProviderExternal(CalculatorProvider::class, 'provideAdditions')]
+    public function test_add(int $a, int $b, int $expected): void
+    {
+        $this->assertSame($expected, $this->calculator->add($a, $b));
+    }
+
+    #[DataProvider('provideSubstractions')]
+    public function test_subtract(int $a, int $b, int $expected): void
+    {
+        $this->assertSame($expected, $this->calculator->subtract($a, $b));
+    }
+
+    public static function provideSubstractions(): iterable
+    {
+        yield [5, 3, 2];
+        yield [5, -5, 10];
+        yield [5, 5, 0];
+    }
+
+    public function test_multiply(): void
+    {
+        $this->assertSame(15, $this->calculator->multiply(3, 5));
+        $this->assertSame(-15, $this->calculator->multiply(-3, 5));
+        $this->assertSame(0, $this->calculator->multiply(0, 5));
+    }
+
+    public function test_divide(): void
+    {
+        $this->assertSame(2.5, $this->calculator->divide(5, 2));
+        $this->assertSame(-2.5, $this->calculator->divide(-5, 2));
+        $this->assertSame(1.0, $this->calculator->divide(5, 5));
+    }
+
+    public function test_divide_by_zero_throws_exception(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Division by zero');
+        $this->calculator->divide(5, 0);
+    }
+
+    public function test_is_positive(): void
+    {
+        $this->assertTrue($this->calculator->isPositive(5));
+        $this->assertFalse($this->calculator->isPositive(-5));
+        $this->assertTrue($this->calculator->isPositive(0));
+    }
+
+    public function test_absolute(): void
+    {
+        $this->assertSame(5, $this->calculator->absolute(5));
+        $this->assertSame(5, $this->calculator->absolute(-5));
+    }
+
+    public function test_absolute_zero(): void
+    {
+        // Test edge case: 0 should not be negated (0 is not less than 0)
+        $result = $this->calculator->absolute(0);
+        $this->assertSame(0, $result);
+
+        // Test boundary values - ensure the comparison is strictly less than, not less than or equal
+        $this->assertSame(1, $this->calculator->absolute(1));
+        $this->assertSame(1, $this->calculator->absolute(-1));
+
+        // Verify that 0 behaves the same as positive numbers (returned as-is)
+        // If the mutant changes < to <=, it would negate 0, but -0 === 0 in PHP
+        // This mutant is technically equivalent and cannot be caught
+        $this->assertTrue($result === 0);
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/tests/Covered/FunctionsTest.php
+++ b/tests/e2e/PHPUnit_13-3/tests/Covered/FunctionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Tests\Covered;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+use function Infection\E2ETests\PHPUnit_13_3\Covered\formatName;
+
+#[CoversFunction('Infection\E2ETests\PHPUnit_13_3\Covered\formatName')]
+class FunctionsTest extends TestCase
+{
+    public function test_format_name_with_both_names(): void
+    {
+        $this->assertSame('John Doe', formatName('John', 'Doe'));
+    }
+
+    public function test_format_name_with_first_name_only(): void
+    {
+        $this->assertSame('John', formatName('John', ''));
+    }
+
+    public function test_format_name_with_last_name_only(): void
+    {
+        $this->assertSame('Doe', formatName('', 'Doe'));
+    }
+
+    public function test_format_name_with_no_names(): void
+    {
+        $this->assertSame('Anonymous', formatName('', ''));
+    }
+}

--- a/tests/e2e/PHPUnit_13-3/tests/Covered/UserServiceTest.php
+++ b/tests/e2e/PHPUnit_13-3/tests/Covered/UserServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Infection\E2ETests\PHPUnit_13_3\Tests\Covered;
+
+use Infection\E2ETests\PHPUnit_13_3\Covered\LoggerTrait;
+use Infection\E2ETests\PHPUnit_13_3\Covered\UserService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\TestCase;
+
+#[CoversTrait(LoggerTrait::class)]
+#[CoversClass(UserService::class)]
+class UserServiceTest extends TestCase
+{
+    private UserService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new UserService();
+    }
+
+    public function test_add_user_successfully(): void
+    {
+        $result = $this->service->addUser('John Doe', 'john@example.com');
+
+        $this->assertTrue($result);
+        $this->assertSame(1, $this->service->getUserCount());
+        $this->assertTrue($this->service->hasLogs());
+    }
+
+    public function test_add_user_with_empty_name_fails(): void
+    {
+        $result = $this->service->addUser('', 'john@example.com');
+
+        $this->assertFalse($result);
+        $this->assertSame(0, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to add user: empty name or email', $logs[0]);
+    }
+
+    public function test_add_user_with_empty_email_fails(): void
+    {
+        $result = $this->service->addUser('John Doe', '');
+
+        $this->assertFalse($result);
+        $this->assertSame(0, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to add user: empty name or email', $logs[0]);
+    }
+
+    public function test_add_duplicate_user_fails(): void
+    {
+        $this->service->addUser('John Doe', 'john@example.com');
+        $this->service->clearLogs();
+
+        $result = $this->service->addUser('Jane Doe', 'john@example.com');
+
+        $this->assertFalse($result);
+        $this->assertSame(1, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to add user: email john@example.com already exists', $logs[0]);
+    }
+
+    public function test_remove_user_successfully(): void
+    {
+        $this->service->addUser('John Doe', 'john@example.com');
+        $this->service->clearLogs();
+
+        $result = $this->service->removeUser('john@example.com');
+
+        $this->assertTrue($result);
+        $this->assertSame(0, $this->service->getUserCount());
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('User john@example.com removed successfully', $logs[0]);
+    }
+
+    public function test_remove_non_existent_user_fails(): void
+    {
+        $result = $this->service->removeUser('john@example.com');
+
+        $this->assertFalse($result);
+
+        $logs = $this->service->getLogs();
+        $this->assertCount(1, $logs);
+        $this->assertSame('Failed to remove user: email john@example.com not found', $logs[0]);
+    }
+
+    public function test_get_user_returns_user_data(): void
+    {
+        $this->service->addUser('John Doe', 'john@example.com');
+        $user = $this->service->getUser('john@example.com');
+
+        $this->assertIsArray($user);
+        $this->assertSame('John Doe', $user['name']);
+        $this->assertSame('john@example.com', $user['email']);
+    }
+
+    public function test_get_user_returns_null_for_non_existent_user(): void
+    {
+        $user = $this->service->getUser('john@example.com');
+
+        $this->assertNull($user);
+    }
+
+    public function test_user_exists(): void
+    {
+        $this->assertFalse($this->service->userExists('john@example.com'));
+
+        $this->service->addUser('John Doe', 'john@example.com');
+
+        $this->assertTrue($this->service->userExists('john@example.com'));
+    }
+
+    public function test_logger_trait_methods(): void
+    {
+        $this->assertFalse($this->service->hasLogs());
+        $this->assertEmpty($this->service->getLogs());
+
+        $this->service->addUser('John Doe', 'john@example.com');
+
+        $this->assertTrue($this->service->hasLogs());
+        $this->assertNotEmpty($this->service->getLogs());
+
+        $this->service->clearLogs();
+
+        $this->assertFalse($this->service->hasLogs());
+        $this->assertEmpty($this->service->getLogs());
+    }
+
+    public function test_log_method_is_public(): void
+    {
+        // Test that log() method can be called from outside the class
+        // If it's protected, this will cause a fatal error
+        $reflection = new \ReflectionMethod(UserService::class, 'log');
+        $this->assertTrue($reflection->isPublic(), 'log() method must be public');
+
+        // Also test we can actually call it
+        $this->service->log('Direct log call');
+        $logs = $this->service->getLogs();
+        $this->assertContains('Direct log call', $logs);
+    }
+}

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -348,6 +348,12 @@ final class PhpUnitAdapterTest extends TestCase
         yield [true, '12.2.99'];
 
         yield [true, '13.0'];
+
+        yield [true, '13.2.99'];
+
+        yield [false, '13.3'];
+
+        yield [false, '14.0'];
     }
 
     #[DataProvider('coverageWithoutSourceProvider')]

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -435,6 +435,20 @@ final class InitialConfigBuilderTest extends TestCase
         $this->assertSame($expectedNodeCount, $nodes->length);
     }
 
+    #[DataProvider('executionOrderValueProvider')]
+    public function test_it_adds_the_execution_order_supported_by_the_phpunit_version(
+        string $version,
+        string $expectedExecutionOrder,
+    ): void {
+        $xml = $this->filesystem->readFile($this->builder->build($version));
+
+        $executionOrder = $this->queryXpath($xml, '/phpunit/@executionOrder');
+
+        $this->assertInstanceOf(DOMNodeList::class, $executionOrder);
+
+        $this->assertSame($expectedExecutionOrder, $executionOrder[0]->value);
+    }
+
     public function test_it_does_not_update_order_if_it_is_already_set(): void
     {
         $phpunitXmlPath = self::FIXTURES . '/phpunit_with_order_set.xml';
@@ -574,6 +588,19 @@ final class InitialConfigBuilderTest extends TestCase
             '7.3.1',
             'resolveDependencies',
             1,
+        ];
+    }
+
+    public static function executionOrderValueProvider(): iterable
+    {
+        yield 'PHPUnit 12.2.7 orders by defects and randomly' => [
+            '12.2.7',
+            'defects,random',
+        ];
+
+        yield 'PHPUnit 13.3 only orders randomly, it records no test run history' => [
+            '13.3',
+            'random',
         ];
     }
 

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -191,6 +191,21 @@ final class InitialConfigBuilderTest extends TestCase
         $this->assertSame('false', $cacheResult);
     }
 
+    public function test_it_disables_caching_for_phpunit_13_3(): void
+    {
+        $xml = $this->filesystem->readFile($this->builder->build('13.3'));
+
+        $cacheResult = $this->queryXpath($xml, '/phpunit/@cacheResult');
+
+        $this->assertInstanceOf(DOMNodeList::class, $cacheResult);
+
+        $this->assertSame(0, $cacheResult->length);
+
+        $recordTestRunHistory = $this->queryXpath($xml, '/phpunit/@recordTestRunHistory')[0]->nodeValue;
+
+        $this->assertSame('false', $recordTestRunHistory);
+    }
+
     public function test_it_deactivates_stderr_redirection(): void
     {
         $xml = $this->filesystem->readFile($this->builder->build('6.5'));

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -602,7 +602,7 @@ final class XmlConfigurationManipulatorTest extends TestCase
 
             XML,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->deactivateResultCaching($xPath);
+                $configManipulator->deactivateResultCaching('11.0', $xPath);
             },
             <<<'XML'
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -643,7 +643,7 @@ final class XmlConfigurationManipulatorTest extends TestCase
             </phpunit>
             XML,
             static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
-                $configManipulator->deactivateResultCaching($xPath);
+                $configManipulator->deactivateResultCaching('11.0', $xPath);
             },
             <<<'XML'
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -658,6 +658,31 @@ final class XmlConfigurationManipulatorTest extends TestCase
                     printerClass="Fake\Printer\Class"
                     processIsolation="false"
                     stopOnFailure="false"
+                    syntaxCheck="false"
+                >
+                </phpunit>
+                XML,
+        );
+    }
+
+    public function test_it_sets_record_test_run_history_to_false_for_phpunit_13_3(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <phpunit
+                cacheResult="true"
+                syntaxCheck="false"
+            >
+            </phpunit>
+            XML,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->deactivateResultCaching('13.3', $xPath);
+            },
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <phpunit
+                    cacheResult="true"
+                    recordTestRunHistory="false"
                     syntaxCheck="false"
                 >
                 </phpunit>
@@ -705,6 +730,31 @@ final class XmlConfigurationManipulatorTest extends TestCase
                 <?xml version="1.0" encoding="UTF-8"?>
                 <phpunit
                     stderr="false"
+                    syntaxCheck="false"
+                >
+                </phpunit>
+                XML,
+        );
+    }
+
+    public function test_it_activates_result_cache_and_execution_order_defects_for_phpunit_13_3(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <phpunit
+                syntaxCheck="false"
+            >
+            </phpunit>
+            XML,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->handleResultCacheAndExecutionOrder('13.3', $xPath, 'a1b2c3', '/tmp');
+            },
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <phpunit
+                    executionOrder="defects"
+                    recordTestRunHistory="true"
+                    cacheDirectory="/tmp/.phpunit.result.cache.a1b2c3"
                     syntaxCheck="false"
                 >
                 </phpunit>


### PR DESCRIPTION
## Description

PHPUnit 13.3 deprecated the `cacheResult` attribute in favour of `recordTestRunHistory`. Its config loader reports a test runner deprecation when `cacheResult` is present and `recordTestRunHistory` is not, so on 13.3 every Infection run reports a deprecation the project did not cause. A project with `failOnPhpunitDeprecation="true"` then gets exit code 1 from the initial test run, and Infection aborts with `Project tests must be in a passing state before running Infection.` even though the suite passed.

`recordTestRunHistory` short-circuits that check, so writing it in the generated configurations is enough.

## Changes

- Disable the `defects` PHPUnit test order for 13.3+.
- Disable `recordTestRunHistory` instead of `cacheResult` in 13.3+.

## Checklist

- [x] Tests added/updated
- [x] Appropriate labels applied (e.g. `performance`, `feature`) — I cannot apply them, `Bugfix` and `TestFramework / PHPUnit` look right.

## Related issues

Fixes https://github.com/infection/infection/issues/3445.
