### PR TITLE
sa: Ignore Mago's unhandled-thrown-type in tests

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -4945,42 +4945,6 @@ message = "Possible argument type mismatch for argument #3 of `sprintf`: expecte
 count = 2
 
 [[issues]]
-file = "tests/benchmark/AstProcessing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `{closure:tests/benchmark/AstProcessing/create-main.php:226:12}`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/AstProcessing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Benchmark\AstProcessing\collectTraces`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/AstProcessing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Benchmark\AstProcessing\collectTraces`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/AstProcessing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Benchmark\AstProcessing\collectTraces`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/AstProcessing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Benchmark\AstProcessing\collectTraces`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/AstProcessing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Benchmark\AstProcessing\collectTraces`.'
-count = 1
-
-[[issues]]
 file = "tests/benchmark/AstProcessing/profile.php"
 code = "invalid-callable"
 message = "Expression of type `mixed` cannot be called as a function or method."
@@ -5029,12 +4993,6 @@ message = 'Could not infer a precise return type for function `Infection\Benchma
 count = 1
 
 [[issues]]
-file = "tests/benchmark/BlackfireInstrumentor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Throwable` in `Infection\Benchmark\BlackfireInstrumentor::profileSample`.'
-count = 1
-
-[[issues]]
 file = "tests/benchmark/MutationGenerator/MutationGeneratorBench.php"
 code = "invalid-callable"
 message = "Expression of type `mixed` cannot be called as a function or method."
@@ -5056,18 +5014,6 @@ count = 1
 file = "tests/benchmark/MutationGenerator/create-main.php"
 code = "possibly-false-argument"
 message = "The first value for `require_once` might be `false`."
-count = 1
-
-[[issues]]
-file = "tests/benchmark/MutationGenerator/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `{closure:tests/benchmark/MutationGenerator/create-main.php:111:12}`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/MutationGenerator/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:tests/benchmark/MutationGenerator/create-main.php:111:12}`.'
 count = 1
 
 [[issues]]
@@ -5131,21 +5077,9 @@ message = "Redundant `===` comparison: left-hand side is never identical to righ
 count = 3
 
 [[issues]]
-file = "tests/benchmark/ParseGitDiff/generator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Benchmark\ParseGitDiff\Generator::scaleFileSizes`.'
-count = 1
-
-[[issues]]
 file = "tests/benchmark/ParseGitDiff/parse-diff.php"
 code = "extend-final-class"
 message = 'Class `{anonymous-class:tests/benchmark/ParseGitDiff/parse-diff.php:49:17}` cannot extend final class `Infection\Process\ShellCommandLineExecutor`'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/ParseGitDiff/parse-diff.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:tests/benchmark/ParseGitDiff/parse-diff.php:78:8}`.'
 count = 1
 
 [[issues]]
@@ -5197,42 +5131,6 @@ message = "Redundant cast to `(float)`: the expression already has this type."
 count = 1
 
 [[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Benchmark\Tracing\collectSources`.'
-count = 1
-
-[[issues]]
-file = "tests/benchmark/Tracing/create-main.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `{closure:tests/benchmark/Tracing/create-main.php:132:12}`.'
-count = 1
-
-[[issues]]
 file = "tests/benchmark/Tracing/profile.php"
 code = "invalid-callable"
 message = "Expression of type `mixed` cannot be called as a function or method."
@@ -5272,12 +5170,6 @@ count = 1
 file = "tests/phpunit/AutoReview/ConcreteClassReflector.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ConcreteClassReflector.php"
-code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `ReflectionException` in `{closure:tests/phpunit/AutoReview/ConcreteClassReflector.php:55:13}`."
 count = 1
 
 [[issues]]
@@ -5383,18 +5275,6 @@ message = "Possible argument type mismatch for argument #1 of `ReflectionClass::
 count = 2
 
 [[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\Mutator\MutatorProviderTest::test_concrete_mutator_class_provider_is_valid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\Mutator\MutatorProviderTest::test_configurable_mutator_class_provider_is_valid`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #1 of `Safe\class_implements`: expected `object|string`, but found `mixed`.'
@@ -5443,24 +5323,6 @@ message = "This condition (type `true`) will always evaluate to true."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\Mutator\MutatorTest::test_configurable_mutators_declare_a_mutator_config`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\Mutator\MutatorTest::test_mutators_do_not_declare_public_methods`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\AutoReview\Mutator\MutatorTest::test_mutators_have_a_definition`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `docBlocksProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -5485,39 +5347,9 @@ message = "Type `iterable` in return type of `provideBenchmarks` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\BenchmarkSmokeTest::test_all_the_benchmarks_can_be_executed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\BenchmarkSmokeTest::test_all_the_benchmarks_can_be_executed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\BenchmarkSmokeTest::test_all_the_benchmarks_can_be_executed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Tests\BenchmarkSmokeTest::test_all_the_benchmarks_can_be_executed`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\CI\ConfigurableEnv::setVariables`: expected `array<string, false|string>`, but possibly received `array{'TRAVIS': true}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/CI/NullCiDetectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OndraM\CiDetector\Exception\CiNotDetectedException` in `Infection\Tests\CI\NullCiDetectorTest::test_it_does_not_detect_any__ci`.'
 count = 1
 
 [[issues]]
@@ -5533,12 +5365,6 @@ message = 'Potential static method call on interface `Infection\Command\Option\C
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/CommandOptionTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\RuntimeException` in `Infection\Tests\Command\CommandOptionTestCase::test_it_maps_the_option`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `astProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -5551,159 +5377,21 @@ message = "Type `iterable` in return type of `invalidFileProvider` is imprecise,
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\DumpAstCommand\DumpAstCommandTest::test_it_outputs_the_ast_of_a_file`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidTimeValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::test_it_handles_empty_log_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::test_it_outputs_log_lines_from_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Debug\MockTeamCityCommandTest::test_it_reads_log_from_stdin_when_no_file_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_can_describe_a_mutator_when_asked_for_a_name`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_described_the_remedy`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_describes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\DescribeCommandTest::test_it_errors_when_mutator_does_not_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\DescribeCommandTest::test_it_can_describe_a_mutator_when_asked_for_a_name`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\DescribeCommandTest::test_it_described_the_remedy`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\DescribeCommandTest::test_it_describes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/DescribeCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\DescribeCommandTest::test_it_errors_when_mutator_does_not_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitBaseReferenceCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitBaseReferenceCommandTest::test_it_outputs_the_base_reference_with_provided_base`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `commandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::test_it_outputs_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitChangedFilesCommandTest::test_it_outputs_paths_relative_to_the_current_working_directory`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `commandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitChangedLinesCommandTest::test_it_outputs_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitDefaultBaseCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\Git\GitDefaultBaseCommandTest::test_it_outputs_the_default_base`.'
 count = 1
 
 [[issues]]
@@ -5719,123 +5407,15 @@ message = "Type `iterable` in return type of `successfulCommandExecutionProvider
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::createCommandTester`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\InitialTest\InitialTestRunCommandTest::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::runCommand`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_all_source_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/ListSourcesCommand/ListSourcesCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\ListSourcesCommand\ListSourcesCommandTest::test_it_lists_filtered_source_files_and_warns_about_the_deprecated_filter_option`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$fileSystemMock`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_not_provided_at_command_call`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_argument_value`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_value_from_quetion_helper`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_uppercases_first_letter_of_argument_value`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_uppercases_the_value_from_quetion_helper`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_not_provided_at_command_call`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_create_custom_mutator_when_name_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_argument_value`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_trims_the_value_from_quetion_helper`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_it_uppercases_first_letter_of_argument_value`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\Command\MakeCustomMutatorCommandTest::test_uppercases_the_value_from_quetion_helper`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/Option/PathsArgumentTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Option/PathsArgumentTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\RuntimeException` in `Infection\Tests\Command\Option\PathsArgumentTest::createIo`.'
 count = 1
 
 [[issues]]
@@ -5891,54 +5471,6 @@ file = "tests/phpunit/Command/RunCommandHelperTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Resource\Processor\DummyCpuCoresCountProvider` not found.'
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_a_positional_argument_is_an_fqcn`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_a_positional_path_does_not_exist_on_disk`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_both_test_framework_option_names_are_passed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_positional_source_path_and_filter_option_are_both_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_positional_source_path_and_git_diff_filter_are_both_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_positional_test_path_and_test_framework_extra_args_are_both_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_show_mutations_value_is_string_but_not_max`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Command\RunCommandTest::test_it_fails_when_threads_value_is_string_but_not_max`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
@@ -6001,18 +5533,6 @@ message = "Type `iterable` in return type of `excludeDirsProvider` is imprecise,
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Random\RandomException` in `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\Config\ValueProvider\ExcludeDirsProviderTest::tearDown`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `sourceDirectoryPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -6067,30 +5587,6 @@ message = 'Class `Infection\Tests\Fixtures\Resource\Processor\DummyCpuCoresCount
 count = 3
 
 [[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_can_create_a_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_throws_exception_when_not_known_static_analysis_tool_used_as_input`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_can_create_a_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryTest::test_it_throws_exception_when_not_known_static_analysis_tool_used_as_input`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/ConfigurationTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `staticAnalysisToolOptionsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -6136,12 +5632,6 @@ count = 1
 file = "tests/phpunit/Configuration/PositionalPathsClassifier/PositionalPathsClassifierTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideInvalidPaths` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/PositionalPathsClassifier/PositionalPathsClassifierTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\Configuration\PositionalPathsClassifier\PositionalPathsClassifierTest::createExistingPaths`.'
 count = 1
 
 [[issues]]
@@ -6211,45 +5701,15 @@ message = 'Too few arguments provided for method `Infection\Configuration\Schema
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileLoaderTest::test_it_create_a_configuration_from_a_file_path`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidConfigContentsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Configuration\Schema\InvalidFile` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest::test_its_contents_is_retrieved_lazily`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Configuration\Schema\InvalidFile` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest::test_its_contents_is_retrieved_only_once`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationFileTest::test_its_contents_is_retrieved_only_once`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `configurationPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaConfigurationLoaderTest::configurationPathsProvider`.'
 count = 1
 
 [[issues]]
@@ -6262,12 +5722,6 @@ count = 1
 file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Configuration\Schema\SchemaValidatorTest::createConfigWithContents`.'
 count = 1
 
 [[issues]]
@@ -6286,60 +5740,6 @@ count = 1
 file = "tests/phpunit/Console/ApplicationTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideNonCommandArguments` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_configures_the_input_when_routing_to_the_run_command`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_does_not_alter_routing_for_known_commands`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_preserves_programmatic_interactivity_when_routing_to_the_run_command`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\ApplicationTest::test_it_routes_to_run_command_when_first_argument_is_not_a_known_command`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_configures_the_input_when_routing_to_the_run_command`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_does_not_alter_routing_for_known_commands`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_preserves_programmatic_interactivity_when_routing_to_the_run_command`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_routes_to_run_command_when_first_argument_is_not_a_known_command`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\ApplicationTest::test_it_uses_the_infection_version`.'
 count = 1
 
 [[issues]]
@@ -6391,48 +5791,6 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 9
 
 [[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Exception` in `Infection\Tests\Console\E2ETest::runInfection`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exception\FinderException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Console\E2ETest::runInfection`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Tests\Console\E2ETest::installComposerDeps`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Console/Input/MsiParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -6463,12 +5821,6 @@ message = 'Could not infer a precise return type for function `Infection\Tests\C
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest::getIsSourceFiltered`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Container/ContainerTest.php"
 code = "avoid-catching-error"
 message = "Avoid catching 'Error' class instances."
@@ -6496,36 +5848,6 @@ count = 1
 file = "tests/phpunit/Container/ContainerTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\Container\ContainerTest::test_it_can_build_lazy_source_file_data_factory_that_fails_on_use`.'
 count = 1
 
 [[issues]]
@@ -6571,426 +5893,6 @@ message = "Type `iterable` in return type of `unifiedDiffProvider` is imprecise,
 count = 1
 
 [[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_max_timeouts_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\EngineTest::test_application_execution_was_finished_is_dispatched_when_min_msi_checker_throws`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\EngineTest::test_initial_test_run_fails`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\EngineTest::test_initial_test_run_succeeds`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\EngineTest::test_max_timeouts_checker_receives_correct_timed_out_count`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_applied_after_static_analysis_when_enabled`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/EngineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\EngineTest::test_memory_limiter_is_not_applied_when_initial_tests_are_skipped`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Environment/BuildContextResolverTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideBlankOrEmptyString` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7000,36 +5902,6 @@ count = 1
 file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Environment\StrykerApiKeyResolver::resolve`: expected `array<string, string>`, but possibly received `array{'API_KEY': string('foo'), 'INFECTION_DASHBOARD_API_KEY': int(9000), 'STRYKER_DASHBOARD_API_KEY': stdClass}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Environment\CouldNotResolveStrykerApiKey` in `Infection\Tests\Environment\StrykerApiKeyResolverTest::test_resolve_returns_value_of_infection_badge_api_key_when_available`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Environment\CouldNotResolveStrykerApiKey` in `Infection\Tests\Environment\StrykerApiKeyResolverTest::test_resolve_returns_value_of_stryker_dashboard_api_key_when_available`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Environment\CouldNotResolveStrykerApiKey` in `Infection\Tests\Environment\StrykerApiKeyResolverTest::test_resolve_throws_when_environment_does_not_contain_any_known_environment_variable_names`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Environment\CouldNotResolveStrykerApiKey` in `Infection\Tests\Environment\StrykerApiKeyResolverTest::test_resolve_throws_when_environment_is_empty_array`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/StrykerApiKeyResolverTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Environment\CouldNotResolveStrykerApiKey` in `Infection\Tests\Environment\StrykerApiKeyResolverTest::test_resolve_throws_when_value_of_known_environment_variables_is_not_a_string`.'
 count = 1
 
 [[issues]]
@@ -7189,30 +6061,6 @@ message = 'Possible argument type mismatch for argument #1 of `Infection\Event\S
 count = 2
 
 [[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_a_path_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileStoreTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\FileStoreTest::test_it_reads_file_contents_from_spl_file_info_and_caches_it_until_a_new_file_is_requested`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileSystemTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\FileSystemTestCase::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/FileSystemTestCase.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\FileSystemTestCase::tearDown`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
 code = "ambiguous-object-method-access"
 message = "Cannot statically verify method call on a generic `object` type."
@@ -7261,18 +6109,6 @@ message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\MockVendor::__construct`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/MockVendor.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\MockVendor::emptyVendorBin`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesMockSetup` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7285,12 +6121,6 @@ message = "This member selector uses a non-literal string type (`string`); its s
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\StaticAnalysisToolExecutableFinderTest::test_invalid_custom_path_throws_exception`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `providesMockSetup` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7300,84 +6130,6 @@ count = 1
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::createComposerExecutableFixture`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::createPhpUnitExecutableFixture`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\Finder\TestFrameworkFinderTest::test_invalid_custom_path_throws_exception`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_can_create_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_can_create_multiple_directories`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_can_dump_and_read_a_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_cannot_create_a_directory_where_a_file_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_cannot_dump_a_file_where_a_directory_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_considers_parent_directories_of_dumped_files_readable`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_normalizes_directory_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_overwrites_existing_files_on_dump`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_throws_when_reading_an_unknown_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/InMemoryFileSystemTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\FileSystem\InMemoryFileSystemTest::test_it_tracks_files_independently`.'
 count = 1
 
 [[issues]]
@@ -7435,42 +6187,6 @@ message = "Type `iterable` in return type of `pathsProvider` is imprecise, equiv
 count = 1
 
 [[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::test_it_can_locate_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::test_it_can_locate_one_of_the_given_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::test_it_can_locate_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::test_it_can_locate_one_of_the_given_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::test_it_throws_an_exception_if_file_or_folder_does_not_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileLocatorTest::test_locate_any_throws_exception_if_no_file_could_be_found`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7492,42 +6208,6 @@ count = 1
 file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::test_it_can_locate_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::test_it_can_locate_one_of_the_given_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::test_it_throws_an_exception_if_file_or_folder_does_not_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::test_locate_any_throws_exception_if_no_file_could_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::test_it_can_locate_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Tests\FileSystem\Locator\RootsFileOrDirectoryLocatorTest::test_it_can_locate_one_of_the_given_files`.'
 count = 1
 
 [[issues]]
@@ -7627,12 +6307,6 @@ message = "Type `iterable` in return type of `separatorProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Framework/InfectionVersionTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `OutOfBoundsException` in `Infection\Tests\Framework\InfectionVersionTest::test_it_returns_the_package_pretty_version`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Framework/Iterable/GeneratorFactory/GeneratorFactoryTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `iterableProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7681,90 +6355,6 @@ message = 'Argument type mismatch for argument #2 of `Infection\Tests\TestingUti
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Git\NoGitProjectFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_cannot_the_project_directory_when_there_is_not_git_project`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Git\NoGitProjectFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_the_project_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_fails_at_getting_the_modified_lines_if_getting_the_merge_base_failed_unexpectedly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_fails_at_getting_the_relative_paths_of_the_changed_files_if_getting_the_merge_base_failed_unexpectedly`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_get_the_changed_lines_excluding_the_files_that_are_not_part_of_the_source_directories`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_get_the_changed_lines`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_changed_files_from_a_source_directory_outside_the_working_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_the_absolute_paths_of_the_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_changed_files_from_a_source_directory_outside_the_working_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Tests\Git\CommandLineGitIntegrationTest::checkIfCommitReferenceExists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_changed_files_from_a_source_directory_outside_the_working_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_changed_files_from_a_source_directory_outside_the_working_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Git\CommandLineGitIntegrationTest::checkIfCommitReferenceExists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Git\CommandLineGitIntegrationTest::test_it_gets_changed_files_from_a_source_directory_outside_the_working_directory`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `defaultGitBaseProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -7774,30 +6364,6 @@ count = 1
 file = "tests/phpunit/Git/CommandLineGitTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `gitChangedLinesRangesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Git\NoGitProjectFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_project_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_get_the_changed_lines_ranges_by_files_relative_paths`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_gets_the_absolute_paths_of_the_changed_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Git\CommandLineGitTest::test_it_throws_no_code_to_mutate_exception_when_diff_is_empty`.'
 count = 1
 
 [[issues]]
@@ -7963,64 +6529,10 @@ message = "Type `iterable` in return type of `noExceptionProvider` is imprecise,
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\Metrics\MaxTimeoutsCheckerTest::test_it_does_not_throw`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MaxTimeoutCountReached` in `Infection\Tests\Metrics\MaxTimeoutsCheckerTest::test_it_throws_when_timed_out_count_exceeds_limit`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Metrics/MetricsCalculatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/MetricsCalculatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Metrics\MetricsCalculatorTest::test_calculator_is_memoized`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\Metrics\MinMsiCheckerTest::test_it_does_nothing_if_the_msis_are_too_low_but_we_ignore_it_with_no_mutations_and_there_is_no_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\Metrics\MinMsiCheckerTest::test_it_does_nothing_if_the_scores_barely_passes_with_no_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\Metrics\MinMsiCheckerTest::test_it_does_nothing_if_the_scores_barely_passes`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\Metrics\MinMsiCheckerTest::test_it_suggests_to_increase_the_min_covered_code_msi_if_above_the_limit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\Metrics\MinMsiCheckerTest::test_it_suggests_to_increase_the_min_msi_and_min_covered_code_msi_if_above_the_limit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MinMsiCheckerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Metrics\MinMsiCheckFailed` in `Infection\Tests\Metrics\MinMsiCheckerTest::test_it_suggests_to_increase_the_min_msi_if_above_the_limit`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php"
@@ -8223,18 +6735,6 @@ message = "Type `iterable` in return type of `valuesProvider` is imprecise, equi
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorIntegrationTest::test_it_generates_mutations_for_a_given_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorIntegrationTest::test_it_generates_mutations_for_a_given_file`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `scenarioProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -8251,30 +6751,6 @@ file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.p
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\PhpParser\FakeNode` not found.'
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_traverses_the_source_statements`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_parses_the_source_file_and_yields_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Mutation\FileMutationGenerator\FileMutationGeneratorTest::test_it_traverses_the_source_statements`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationAssertionsTest.php"
@@ -8295,12 +6771,6 @@ message = 'Argument type mismatch for argument #6 of `Infection\Tests\Mutation\M
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutation/MutationBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutation\MutationBuilder::getMutationHashPropertyReflection`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutation/MutationBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -8316,78 +6786,6 @@ count = 1
 file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_dispatches_events`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\Mutation\MutationGeneratorTest::test_it_returns_all_the_mutations_generated_for_each_files`.'
 count = 1
 
 [[issues]]
@@ -9153,18 +7551,6 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\MutatorCategoryTest::test_it_cannot_be_instantiated`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\MutatorCategoryTest::test_it_lists_all_its_exposed_constants`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #4 of `sprintf`: expected `Stringable|null|scalar`, but found `mixed`."
@@ -9219,12 +7605,6 @@ message = 'Possible argument type mismatch for argument #3 of `Infection\Tests\M
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\MutatorFactoryTest::assertSameMutatorsByClass`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/MutatorParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutatorInputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -9234,12 +7614,6 @@ count = 1
 file = "tests/phpunit/Mutator/MutatorParserTest.php"
 code = "non-existent-class-like"
 message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `UnexpectedValueException` in `Infection\Tests\Mutator\MutatorParserTest::test_it_can_parse_the_provided_input`.'
 count = 1
 
 [[issues]]
@@ -9336,18 +7710,6 @@ count = 1
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "possibly-invalid-argument"
 message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `non-empty-array<class-string, array{}>`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\Mutator\MutatorRobustnessTest::mutatesCode`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Mutator\MutatorRobustnessTest::mutatesCode`.'
 count = 1
 
 [[issues]]
@@ -9570,18 +7932,6 @@ count = 1
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\ProfileListProvider::getProfiles`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\ProfileListProvider::implementedMutatorProvider`.'
 count = 1
 
 [[issues]]
@@ -10083,12 +8433,6 @@ message = "Type `iterable` in return type of `mutationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Util/AbstractValueToNullReturnValueTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Mutator\Util\AbstractValueToNullReturnValueTest::invokeMethod`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/Util/ReturnTypeHelperTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nullReturnProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10125,27 +8469,9 @@ message = "This member selector uses a non-literal string type (`string`); its s
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/FakeTokenTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\PhpParser\FakeTokenTest::methodProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/FileParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `fileToParserProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\PhpParser\FileParserTest::test_it_can_parse_a_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Tests\PhpParser\FileParserTest::test_it_parses_the_given_file_only_once`.'
 count = 1
 
 [[issues]]
@@ -10233,12 +8559,6 @@ message = 'Argument #1 passed to method `PhpParser\Parser::parse` has type `neve
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperTest::test_dump_nodes`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `visitorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -10275,27 +8595,9 @@ message = '''Possible argument type mismatch for argument #2 of `Infection\Tests
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorReflection`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitorTest::test_it_adds_an_id_to_each_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\AddIdToTraversedNodesVisitor\AddIdToTraversedNodesVisitorTest::test_it_provides_a_map_of_the_nodes_by_their_id`.'
 count = 1
 
 [[issues]]
@@ -10311,33 +8613,15 @@ message = "Type `iterable` in return type of `nodeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\EnrichmentTraverse\EnrichmentTraverseIntegrationTest::test_it_creates_a_rich_ast`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/ExcludeIgnoredNodesVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/ExcludeIgnoredNodesVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ExcludeIgnoredNodesVisitor\ExcludeIgnoredNodesVisitorTest::test_it_marks_nodes_with_the_ignore_all_comment_as_ignored`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/MarkAllButIneligibleNodesAsVisitedVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/MarkAllButIneligibleNodesAsVisitedVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ExcludeIgnoredNodesVisitor\MarkAllButIneligibleNodesAsVisitedVisitorTest::test_it_labels_visited_nodes_as_visited_and_eligible_nodes_as_mutation_candidates`.'
 count = 1
 
 [[issues]]
@@ -10353,21 +8637,9 @@ message = "Type `iterable` in return type of `nodeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeUnchangedLinesVisitor/ExcludeUnchangedLinesVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ExcludeUnchangedLinesVisitor\ExcludeUnchangedLinesVisitorTest::test_it_marks_nodes_belonging_to_unchanged_lines_as_ineligible`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ExcludeUntestedNodesVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeUntestedNodesVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ExcludeUntestedNodesVisitorTest::test_it_marks_eligible_untested_nodes_as_ineligible`.'
 count = 1
 
 [[issues]]
@@ -10377,21 +8649,9 @@ message = "Type `iterable` in return type of `nodeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\FullyQualifiedClassNameManipulatorTest::test_it_annotates_the_resolved_node_names`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/AbstractMethodIgnorerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/AbstractMethodIgnorerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\IgnoreNode\AbstractMethodIgnorerTest::test_it_ignores_abstract_methods`.'
 count = 1
 
 [[issues]]
@@ -10401,45 +8661,15 @@ message = "Type `iterable` in return type of `nodeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\IgnoreNode\InterfaceIgnorerTest::test_it_ignores_interfaces`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/LabelNodesAsEligibleVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/LabelNodesAsEligibleVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\LabelNodesAsEligibleVisitorTest::test_it_labels_visited_nodes_as_eligible`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest::cloneNodes`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest::test_it_annotates_the_viewed_nodes_as_visited`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\PhpParser\Visitor\MutationCollectorVisitorTest::test_it_collects_the_generated_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutationCollectorVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\PhpParser\Visitor\MutationCollectorVisitorTest::test_it_resets_its_state_between_two_traverse`.'
 count = 1
 
 [[issues]]
@@ -10455,21 +8685,9 @@ message = "Type `iterable` in return type of `nodeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\NextConnectingVisitorTest::test_it_annotates_the_next_nodes`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ParentConnectorTest::test_it_annotates_the_parent_nodes`.'
 count = 1
 
 [[issues]]
@@ -10479,21 +8697,9 @@ message = "Type `iterable` in return type of `nodeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\ReflectionVisitorTest::test_it_annotates_excluded_nodes_and_stops_the_traversal`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/Visitor/SkipIgnoredNodesVisitor/SkipIgnoredNodesVisitorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/SkipIgnoredNodesVisitor/SkipIgnoredNodesVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\PhpParser\Visitor\SkipIgnoredNodesVisitor\SkipIgnoredNodesVisitorTest::test_it_skips_the_traversal_of_ignored_nodes_and_its_children`.'
 count = 1
 
 [[issues]]
@@ -10530,30 +8736,6 @@ count = 1
 file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_injects_xdebug_env_vars`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessStartFailedException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_injects_xdebug_env_vars`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_injects_xdebug_env_vars`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/OriginalPhpProcessTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Tests\Process\OriginalPhpProcessTest::test_it_injects_xdebug_env_vars`.'
 count = 1
 
 [[issues]]
@@ -10647,12 +8829,6 @@ message = "Possible argument type mismatch for argument #1 of `array_filter`: ex
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\RuntimeException` in `Infection\Tests\Process\Runner\InitialTestsRunnerTest::test_it_stops_the_process_execution_on_the_first_error`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "invalid-method-access"
 message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`).'
@@ -10731,12 +8907,6 @@ message = 'Possible argument type mismatch for argument #4 of `Infection\Process
 count = 6
 
 [[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\MutationTestingRunnerTest::invokeMethod`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "impossible-assignment"
 message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
@@ -10779,123 +8949,9 @@ message = "Redundant `<=` comparison: left-hand side is always less than or equa
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_has_processes_that_could_be_freed_greater_than_or_equal_to_behavior`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_finished_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_mark_as_timed_out_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_call_removal_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_decrement_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_increment_integer_mutation`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Process\Runner\ParallelProcessRunnerTest::test_wait_method_with_minus_mutation`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `commandProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_does_not_include_stderr_in_output`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_does_not_provide_interactive_input`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_executes_command_and_returns_trimmed_output`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_throws_exception_on_command_failure`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_does_not_include_stderr_in_output`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_does_not_provide_interactive_input`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_executes_command_and_returns_trimmed_output`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_throws_exception_on_command_failure`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_does_not_include_stderr_in_output`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_does_not_provide_interactive_input`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_executes_command_and_returns_trimmed_output`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\Process\ShellCommandLineExecutorTest::test_it_throws_exception_on_command_failure`.'
 count = 1
 
 [[issues]]
@@ -10959,27 +9015,9 @@ message = "Redundant docblock type for variable `$returnTypeClassName`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reflection/ContainerReflection.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Reflection\ContainerReflection::__construct`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/ContainerReflection.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Reflection\ContainerReflection::iterateExpectedConcreteServices`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Report/Framework/Writer/FileWriterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `contentsOrLinesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Report/Framework/Writer/FileWriterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\Report\Framework\Writer\FileWriterTest::test_it_can_write_contents_or_lines_to_the_file`.'
 count = 1
 
 [[issues]]
@@ -11094,12 +9132,6 @@ count = 1
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "non-existent-class"
 message = 'Class `Infection\Tests\Fixtures\Logger\FakeLogger` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Reporter\FileReporterFactoryTest::assertRegisteredReportersAre`.'
 count = 1
 
 [[issues]]
@@ -11319,12 +9351,6 @@ message = "Too few arguments provided for method `ReflectionProperty::setValue`.
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\Resource\Memory\MemoryLimiterEnvironmentTest::test_it_does_not_use_the_system_ini_if_phpdbg_is_disabled_and_xdebug_handler_is_detected`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
 code = "impossible-assignment"
 message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
@@ -11421,51 +9447,9 @@ message = 'Possible argument type mismatch for argument #2 of `Infection\Source\
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest::test_it_can_collect_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest::test_it_filters_the_collected_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest::test_it_filters_the_collected_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/CachedSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\CachedSourceCollectorTest::test_it_caches_the_collected_files`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Source/Collector/LazySourceCollectorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `decoratedCollectorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/LazySourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\LazySourceCollectorTest::test_it_decorates_the_given_collector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/LazySourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\LazySourceCollectorTest::test_it_does_not_consume_the_factory_unless_necessary`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/MemoizedSourceCollectorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Collector\MemoizedSourceCollectorTest::test_it_memoizes_the_collected_files`.'
 count = 1
 
 [[issues]]
@@ -11499,93 +9483,15 @@ message = "Redundant docblock type for variable `$git`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::test_it_memoizes_parsed_results`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Matcher\GitDiffSourceLineMatcherTest::test_it_tells_if_the_mutation_touches_any_of_the_changed_lines`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Source/Matcher/SimpleSourceLineMatcherTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideLines` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Matcher/SimpleSourceLineMatcherTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\Source\Matcher\SimpleSourceLineMatcherTest::test_it_tells_if_the_mutation_touches_any_of_the_changed_lines`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideValidVersions` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_accepts_valid_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_rejects_invalid_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessFailedException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessSignaledException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_retrieves_version_with_the_shell_command_line_executor`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Tests\StaticAnalysis\Mago\Adapter\MagoAdapterTest::test_it_returns_version`.'
 count = 1
 
 [[issues]]
@@ -11613,36 +9519,6 @@ message = 'Impossible type assertion: `$traces` of type `array<array-key, Infect
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\CoveredTraceProviderTest::test_it_provides_traces`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `defaultCovergageDirectoryProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -11661,228 +9537,6 @@ message = "Type `iterable` in return type of `reportPathnameProvider` is impreci
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_locate_the_report_if_the_source_directory_is_not_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_locate_the_report_if_the_source_directory_is_not_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_locate_the_report_if_the_source_directory_is_not_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitReportLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$actual`."
@@ -11892,30 +9546,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "unevaluated-code"
 message = "Unreachable code detected."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `Exception` in `{closure:tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php:173:19}`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_adds_if_junit_is_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_add_if_junit_is_not_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdderTest::test_it_does_not_load_the_trace_tests_until_necessary`.'
 count = 1
 
 [[issues]]
@@ -11943,36 +9573,6 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::test_it_can_get_the_test_info_for_a_given_test_id`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::test_it_is_idempotent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `{closure:tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php:112:17}`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `{closure:tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php:115:17}`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider\JUnitTestFileDataProviderTest::setUp`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -11997,210 +9597,6 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/MemoizedTestFileDataProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\JUnit\MemoizedTestFileDataProviderTest::test_it_memoize_get_test_file_info_calls`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found_if_the_result_is_located_at_the_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_returns_the_default_path_if_it_exists`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_caches_the_result_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/BaseReportLocator/BaseReportLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\Locator\BaseReportLocator\BaseReportLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest::test_it_can_be_instantiated_with_a_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest::test_it_can_be_instantiated_without_a_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest::test_it_can_be_instantiated_with_a_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest::test_it_can_be_instantiated_without_a_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest::test_it_can_be_instantiated_with_a_default_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/Locator/FixedLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\Locator\FixedLocatorTest::test_it_can_be_instantiated_without_a_default_location`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `defaultCovergageDirectoryProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -12219,234 +9615,6 @@ message = "Type `iterable` in return type of `reportPathnameProvider` is impreci
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_report_if_the_source_directory_is_not_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_report_if_the_source_directory_is_not_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_no_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_the_source_directory_is_invalid`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_report_if_the_source_directory_is_not_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_find_a_report_pathname`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_default_report_with_the_wrong_case_on_a_case_insensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_can_locate_the_report_with_the_wrong_case`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_if_there_is_more_than_one_valid_report`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_find_the_report_no_suitable_file_was_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_default_report_with_the_wrong_case_on_a_case_sensitive_system`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_cannot_locate_the_report_if_the_source_directory_is_not_a_directory`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocatorTest::test_it_the_default_path_of_this_test_is_not_the_standard_location`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `indexProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -12456,60 +9624,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `noCoveredLineReportProviders` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest::test_it_provides_file_information`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php:121:13}`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php:136:13}`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\Coverage\XmlReport\IndexXmlCoverageParser\IndexXmlCoverageParserTest::setUp`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/PhpUnitXmlCoverageTraceProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Tests\TestFramework\Coverage\XmlReport\PhpUnitXmlCoverageTraceProviderTest::test_it_can_parse_coverage_data`.'
 count = 1
 
 [[issues]]
@@ -12603,21 +9717,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/CodeceptionProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\CodeceptionProvider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpSpecProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpSpecProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpSpecProvider::infoProvider`.'
 count = 1
 
 [[issues]]
@@ -12627,21 +9729,9 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit09Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit09Provider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit10Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit10Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit10Provider::infoProvider`.'
 count = 1
 
 [[issues]]
@@ -12651,45 +9741,21 @@ message = "Type `iterable` in return type of `infoProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit11Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit11Provider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit120Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit120Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit120Provider::infoProvider`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit125Provider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit125Provider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\PhpUnit125Provider::infoProvider`.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `lineCoverageProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\Coverage\XmlReport\XmlCoverageParser\XmlCoverageParserTest::lineCoverageProvider`.'
 count = 1
 
 [[issues]]
@@ -12747,21 +9813,9 @@ message = "Type `iterable` in return type of `syntaxErrorOutputProvider` is impr
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\AbstractTestFramework\InvalidVersion` in `Infection\Tests\TestFramework\PhpUnit\Adapter\PhpUnitAdapter\PhpUnitAdapterTest::test_it_retrieves_version`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `provideTestCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/CommandLine/TestFrameworkExtraArgsTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `ReflectionException` in `Infection\Tests\TestFramework\PhpUnit\CommandLine\TestFrameworkExtraArgsTest::parseRawTokensWithFallbackTokenizer`.'
 count = 1
 
 [[issues]]
@@ -12799,192 +9853,6 @@ file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderT
 code = "possibly-null-argument"
 message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::normalize` is possibly `null`, but parameter type `string` does not accept it.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::queryXpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_adds_execution_order_for_proper_phpunit_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_adds_fail_on_risky_and_warning_for_proper_phpunit_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_adds_the_execution_order_supported_by_the_phpunit_version`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_builds_and_dump_the_xml_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_a_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_coverage_filter_whitelist_node_if_does_not_exist_and_version_situation_is_uncertain`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_coverage_filter_whitelist_node_if_does_not_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_coverage_include_node_if_does_not_exist_for_10_0_version_of_phpunit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_creates_source_include_node_if_does_not_exist_for_10_1_version_of_phpunit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_deactivates_stderr_redirection`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_deactivates_the_colors`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_disables_caching_for_phpunit_13_3`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_disables_caching`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_add_coverage_loggers_ever_for_latest_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_add_coverage_loggers_ever_for_legacy_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_create_coverage_filter_whitelist_node_if_already_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_create_coverage_include_node_if_already_exist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_create_legacy_coverage_filter_whitelist_node_for_10_0_version_of_phpunit`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_replace_coverage_filter_include_node_for_phpunit_12_even_if_filtered_source_files_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_update_fail_on_risky_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_update_fail_on_warning_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_does_not_update_order_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_ignores_filtered_source_files_for_phpunit_12_when_creating_source_include_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_preserves_white_spaces_and_formatting`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_removes_original_loggers`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_removes_printer_class`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_replaces_bootstrap_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_replaces_coverage_filter_include_node_if_exists_but_filtered_source_files_provided`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_replaces_relative_path_to_absolute_path`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilderTest::test_it_sets_stops_on_failure`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
@@ -13047,132 +9915,6 @@ message = "Reference created from a previously undefined variable `$returnCode`.
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::queryXpath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_interceptor_is_included`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_adds_fail_on_risky_and_warning_for_proper_phpunit_versions`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_builds_and_dump_the_xml_configuration`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_can_build_the_config_for_multiple_mutations`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_deactivates_the_colors`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_does_not_set_default_execution_order_for_phpunit_7_1`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_does_not_update_fail_on_risky_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_does_not_update_fail_on_warning_attributes_if_it_is_already_set`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_handles_root_test_suite`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_preserves_white_spaces_and_formatting`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_removes_default_test_suite`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_removes_original_loggers`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_removes_printer_class`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_custom_autoloader_when_attribute_is_absent`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_custom_autoloader`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_default_execution_order_when_attribute_is_absent_for_phpunit_7_2`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_default_execution_order_when_attribute_is_present_for_phpunit_7_2`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_defects_execution_order_and_cache_result_when_attribute_is_present_for_phpunit_7_3`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_sorted_list_of_test_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Tests\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilderTest::test_it_sets_stops_on_failure`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `pathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -13216,18 +9958,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest::createXPath`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `PHPUnit\Util\Xml\XmlException` in `Infection\Tests\TestFramework\PhpUnit\Config\XmlConfigurationManipulatorTest::assertItChangesXML`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
 code = "unused-parameter"
 message = "Parameter `$file` is never used."
 count = 1
@@ -13266,18 +9996,6 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mainlineConfigurationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `{closure:tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php:59:19}`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `{closure:tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php:67:19}`.'
 count = 1
 
 [[issues]]
@@ -13431,42 +10149,6 @@ message = "Type `iterable` in return type of `locationsProvider` is imprecise, e
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_can_trace_files`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_finds_traces_on_windows`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_handles_empty_trace_provider`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `Infection\Tests\TestFramework\Tracing\TraceProviderAdapterTracerTest::test_it_traverses_and_pauses_the_trace_generator_as_needed_and_caches_the_results`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `{closure:tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php:141:30}`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `{closure:tests/phpunit/TestFramework/Tracing/TraceProviderAdapterTracerTest.php:144:30}`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Tracer/CodeceptionProvider.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -13521,12 +10203,6 @@ message = 'Class `Infection\Tests\Fixtures\TestFramework\Coverage\JUnit\FakeTest
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Tracing\Throwable\NoTraceFound` in `Infection\Tests\TestFramework\Tracing\Tracer\TracerIntegrationTest::test_it_can_create_a_trace`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `invalidXmlProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -13563,216 +10239,6 @@ message = "Attempting to access a property on a possibly `null` value."
 count = 6
 
 [[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_for_an_xml_file_with_a_namespace_registered`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_for_an_xml_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_for_an_xml_string_with_a_namespace_registered`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_for_an_xml_string_without_a_namespace`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_for_an_xml_string`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_be_created_with_a_formatted_output`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_query_an_attribute_relative_to_another_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_query_an_attribute`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_query_an_element_relative_to_another_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_query_an_element`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_query_elements_relative_to_another_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_can_query_elements`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_be_created_for_an_xml_file_with_a_namespace_registered_if_the_document_has_no_namespace`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_be_created_for_an_xml_string_with_a_namespace_registered_if_the_document_has_no_namespace`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_a_non_dom_element`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_attribute_for_which_there_is_more_than_one_item`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_attribute_with_a_dom_node_that_cannot_be_fetched`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_attribute_with_an_invalid_context_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_attribute_with_an_invalid_query`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_element_for_which_there_is_more_than_one_item`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_element_with_a_dom_node_that_cannot_be_fetched`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_element_with_an_invalid_context_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_an_element_with_an_invalid_query`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_count_with_a_query_with_an_invalid_context_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_the_count_with_a_query_with_a_dom_node_that_cannot_be_fetched`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_the_count_with_an_invalid_query`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_with_a_query_with_a_dom_node_that_cannot_be_fetched`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_with_a_query_with_an_invalid_context_node`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_cannot_query_with_an_invalid_query`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_has_document_property`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_returns_null_if_the_attribute_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_returns_null_if_the_element_could_not_be_found`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_throws_an_exception_when_creating_it_from_an_invalid_xml_file`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_throws_an_exception_when_creating_it_from_an_invalid_xml_string`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\Tests\TestFramework\XML\SafeDOMXPath\SafeDOMXPathTest::test_it_throws_if_it_cannot_get_a_dom_element`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php"
 code = "non-existent-class-like"
 message = 'Class, Interface, or Trait `Infection\Tests\Fixtures\Mutator\CustomNameMutator` does not exist.'
@@ -13803,24 +10269,6 @@ message = "Type `iterable` in return type of `commandLineProvider` is imprecise,
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Testing/TestFramework/Debug/DebugCommandLineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exception\FinderException` in `Infection\Tests\Testing\TestFramework\Debug\DebugCommandLineTest::test_it_builds_a_self_describing_command`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/TestFramework/Debug/DebugCommandLineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exception\FinderException` in `Infection\Tests\Testing\TestFramework\Debug\DebugCommandLineTest::test_it_cannot_build_a_command_without_a_php_executable`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/TestFramework/Debug/DebugCommandLineTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exception\FinderException` in `Infection\Tests\Testing\TestFramework\Debug\DebugCommandLineTest::test_it_memoizes_the_php_executable`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Testing/TestFramework/Debug/DebugTestFrameworkAdapterTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `initialCommandLineProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -13836,18 +10284,6 @@ count = 1
 file = "tests/phpunit/TestingUtility/Console/Command/TestOptionCommand.php"
 code = "possibly-static-access-on-interface"
 message = 'Potential static method call on interface `Infection\Command\Option\CommandOption` via `class-string`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Console/Command/TestOptionCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\RuntimeException` in `Infection\Tests\TestingUtility\Console\Command\TestOptionCommand::bind`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/FS.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Random\RandomException` in `Infection\Tests\TestingUtility\FS::tmpDir`.'
 count = 1
 
 [[issues]]
@@ -13929,12 +10365,6 @@ message = "Type `iterable` in return type of `nodeProvider` is imprecise, equiva
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitorTest.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Tests\TestingUtility\PhpParser\Visitor\SkipNodesVisitor\SkipNodesVisitorTest::test_it_skips_encountered_nodes`.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/WithConsecutive.php"
 code = "imprecise-type"
 message = "Type `array` in return type of `create` is imprecise, equivalent to `array<array-key, mixed>`."
@@ -13974,10 +10404,4 @@ count = 2
 file = "tests/phpunit/WithConsecutive.php"
 code = "possibly-null-operand"
 message = "Right operand in `<` comparison might be `null` (type `non-negative-int|null`)."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `RuntimeException` in `Infection\Tests\WithConsecutive::create`.'
 count = 1

--- a/mago.toml
+++ b/mago.toml
@@ -61,6 +61,9 @@ unchecked-exceptions = [
     "Psr\\Container\\ContainerExceptionInterface",
     "Safe\\Exceptions\\SafeExceptionInterface",
 ]
+ignore = [
+    { code = "unhandled-thrown-type", in = ["tests/"] },
+]
 check-missing-override = false
 find-unused-parameters = true
 strict-list-index-checks = false

--- a/tests/phpunit/Testing/TestFramework/Debug/DebugStaticAnalysisAdapterTest.php
+++ b/tests/phpunit/Testing/TestFramework/Debug/DebugStaticAnalysisAdapterTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Testing\TestFramework\Debug;
 
-use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\Testing\TestFramework\Debug\DebugCommandLine;
 use Infection\Testing\TestFramework\Debug\DebugStaticAnalysisAdapter;
 use Infection\Testing\TestFramework\Debug\DebugStaticAnalysisMutantProcessFactory;
@@ -46,7 +45,6 @@ use Symfony\Component\Process\PhpExecutableFinder;
 #[CoversClass(DebugStaticAnalysisAdapter::class)]
 final class DebugStaticAnalysisAdapterTest extends TestCase
 {
-    /** @throws FinderException */
     public function test_it_builds_debug_processes(): void
     {
         $phpExecutableFinder = $this->createStub(PhpExecutableFinder::class);

--- a/tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowablesTest.php
+++ b/tests/phpunit/TestingUtility/PHPUnit/ExpectsThrowablesTest.php
@@ -64,7 +64,7 @@ final class ExpectsThrowablesTest extends TestCase
     public function test_it_returns_the_thrown_throwable(): void
     {
         $expected = new Exception('The expected exception.');
-        $action = /** @throws Exception */ static fn () => throw $expected;
+        $action = static fn () => throw $expected;
 
         $actual = $this->expectToThrow($action);
 


### PR DESCRIPTION
## Description

PHPUnit calls test methods itself, and an uncaught exception there is simply a failed test. 

Documenting `@throws` on every test method adds nothing of value.

### Reviewer Notes

I set this PR to auto merge as it is trivial.
