### PR TITLE
fix(phpunit): Stop ordering the initial run by defects on PHPUnit 13.3

### DIFF
--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
@@ -213,11 +213,6 @@ final class PhpUnitAdapter extends AbstractTestFrameworkAdapter implements Memor
 
     public static function supportsExecutionOrderDefectsRandom(string $version): bool
     {
-        // ordering by defects needs the test run history, which the initial run deactivates. PHPUnit ignored that combination silently until 13.3 turned it into a warning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
-        if (version_compare($version, '13.3', '>=')) {
-            return false;
-        }
-
         return
             version_compare($version, '10.5.48', '>=') && version_compare($version, '11.0', '<')
             || version_compare($version, '11.5.27', '>=') && version_compare($version, '12.0', '<')

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -35,9 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\PhpUnit\Config;
 
+use function array_filter;
+use DOMAttr;
 use DOMDocument;
 use DOMElement;
 use DOMNode;
+use function explode;
 use const FILTER_VALIDATE_URL;
 use function filter_var;
 use function implode;
@@ -97,10 +100,15 @@ final readonly class XmlConfigurationManipulator
 
     public function deactivateResultCaching(string $version, SafeDOMXPath $xPath): void
     {
-        // PHPUnit 13.3 deprecated cacheResult in favour of recordTestRunHistory
-        $attribute = version_compare($version, '13.3', '>=') ? 'recordTestRunHistory' : 'cacheResult';
+        // PHPUnit 13.3 deprecated cacheResult in favour of recordTestRunHistory, and warns when tests are ordered by defects while that history is not recorded https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
+        if (version_compare($version, '13.3', '>=')) {
+            $this->setAttributeValue($xPath, 'recordTestRunHistory', 'false');
+            $this->removeDefectsFromExecutionOrder($xPath->queryAttribute('/phpunit/@executionOrder'));
 
-        $this->setAttributeValue($xPath, $attribute, 'false');
+            return;
+        }
+
+        $this->setAttributeValue($xPath, 'cacheResult', 'false');
     }
 
     public function handleResultCacheAndExecutionOrder(string $version, SafeDOMXPath $xPath, string $mutationHash, string $tmpDir): void
@@ -347,6 +355,26 @@ final readonly class XmlConfigurationManipulator
             Assert::isInstanceOf($document, DOMElement::class);
             $document->removeAttribute($name);
         }
+    }
+
+    private function removeDefectsFromExecutionOrder(?DOMAttr $executionOrder): void
+    {
+        if ($executionOrder === null) {
+            return;
+        }
+
+        $order = array_filter(
+            explode(',', $executionOrder->value),
+            static fn (string $value): bool => $value !== 'defects',
+        );
+
+        if ($order === []) {
+            $executionOrder->value = 'default';
+
+            return;
+        }
+
+        $executionOrder->value = implode(',', $order);
     }
 
     private function setAttributeValue(SafeDOMXPath $xPath, string $name, string $value): void

--- a/tests/e2e/PHPUnit_13-3/phpunit.xml
+++ b/tests/e2e/PHPUnit_13-3/phpunit.xml
@@ -5,6 +5,7 @@
          colors="true"
          testdoxSummary="true"
          cacheDirectory="var/phpunit-cache"
+         executionOrder="depends,defects"
          failOnPhpunitDeprecation="true"
 >
     <testsuites>

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -349,11 +349,7 @@ final class PhpUnitAdapterTest extends TestCase
 
         yield [true, '13.0'];
 
-        yield [true, '13.2.99'];
-
-        yield [false, '13.3'];
-
-        yield [false, '14.0'];
+        yield [true, '13.3'];
     }
 
     #[DataProvider('coverageWithoutSourceProvider')]

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -690,6 +690,56 @@ final class XmlConfigurationManipulatorTest extends TestCase
         );
     }
 
+    public function test_it_drops_the_defects_execution_order_for_phpunit_13_3(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <phpunit
+                executionOrder="depends,defects"
+                syntaxCheck="false"
+            >
+            </phpunit>
+            XML,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->deactivateResultCaching('13.3', $xPath);
+            },
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <phpunit
+                    executionOrder="depends"
+                    syntaxCheck="false"
+                    recordTestRunHistory="false"
+                >
+                </phpunit>
+                XML,
+        );
+    }
+
+    public function test_it_falls_back_to_the_default_execution_order_for_phpunit_13_3(): void
+    {
+        $this->assertItChangesXML(<<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <phpunit
+                executionOrder="defects"
+                syntaxCheck="false"
+            >
+            </phpunit>
+            XML,
+            static function (XmlConfigurationManipulator $configManipulator, SafeDOMXPath $xPath): void {
+                $configManipulator->deactivateResultCaching('13.3', $xPath);
+            },
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <phpunit
+                    executionOrder="default"
+                    syntaxCheck="false"
+                    recordTestRunHistory="false"
+                >
+                </phpunit>
+                XML,
+        );
+    }
+
     public function test_it_sets_stderr_to_false_when_it_exists(): void
     {
         $this->assertItChangesXML(<<<'XML'


### PR DESCRIPTION
## Description

On PHPUnit 13.3 the generated initial config pairs `recordTestRunHistory="false"` with whatever `executionOrder` the project declares. When that value contains `defects`, PHPUnit warns that tests cannot be ordered by defects while the run history is not recorded, and because Infection also sets `failOnWarning="true"`, the initial run aborts before a single test is executed.

#3447 only guarded the case where Infection itself adds `defects,random`. A project that already declares `executionOrder="defects"` or `"depends,defects"` never reaches that guard, since its value is copied over as is.

`deactivateResultCaching()` now drops the `defects` component from `executionOrder` whenever it turns the history off, which is what PHPUnit did silently up to 13.2. The two settings can no longer contradict each other regardless of who wrote them, so the 13.3 branch in `supportsExecutionOrderDefectsRandom()` becomes redundant and goes away, and 13.3 orders the initial run like 13.2 again.

## Changes

- Removes `defects` from `executionOrder` in the initial config on PHPUnit >= 13.3, falling back to `default` when nothing else remains
- Reverts the 13.3 special case in `PhpUnitAdapter::supportsExecutionOrderDefectsRandom()`
- `tests/e2e/PHPUnit_13-3` now declares `executionOrder="depends,defects"`; on master that fixture fails with the exact error from the issue

## Reviewer Notes

The second commit is the cleanup part, easy to drop if you would rather keep the guard.

Fixes https://github.com/infection/infection/issues/3457
