### PR TITLE
fix: Replace deprecated Node\Scalar\LNumber with Node\Scalar\Int_

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -2299,18 +2299,6 @@ message = 'Potentially unhandled exception `Infection\Mutator\InvalidMutator` in
 count = 1
 
 [[issues]]
-file = "src/Mutator/Number/DecrementInteger.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Number/IncrementInteger.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/Number/OneZeroFloat.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\DNumber` is deprecated and should no longer be used.'
@@ -2320,12 +2308,6 @@ count = 2
 file = "src/Mutator/Operator/SpreadOneItem.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Expr\ArrayItem` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Operator/SpreadOneItem.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
 count = 1
 
 [[issues]]
@@ -2407,21 +2389,9 @@ message = "Invalid type for left operand."
 count = 2
 
 [[issues]]
-file = "src/Mutator/ReturnValue/ArrayOneItem.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 3
-
-[[issues]]
 file = "src/Mutator/ReturnValue/FloatNegation.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\DNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/ReturnValue/IntegerNegation.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
 count = 1
 
 [[issues]]
@@ -3476,26 +3446,8 @@ count = 1
 
 [[issues]]
 file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
-code = "falsable-return-statement"
-message = "Function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:119:21}` is declared to return `string` but possibly returns 'false' (inferred as `false|string`)."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
 code = "incompatible-parameter-type"
 message = 'Parameter `$sourceDirectories` of `Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory::create()` expects type `array<array-key, string>` but parent `Infection\AbstractTestFramework\TestFrameworkAdapterFactory::create()` expects type `array<array-key, mixed>`'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
-code = "invalid-return-statement"
-message = "Invalid return type for function `{closure:src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php:119:21}`: expected `string`, but found `false|string`."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #7 of `Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder::__construct`: expected `array<array-key, string>`, but possibly received `array<array-key, false|string>|list<false|string>`.'
 count = 1
 
 [[issues]]
@@ -4714,14 +4666,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 12
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\Int_}`.'
 count = 5
 
 [[issues]]
@@ -4732,14 +4678,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\Int_}`.'
 count = 2
 
 [[issues]]
@@ -5037,12 +4977,6 @@ message = '''Possible argument type mismatch for argument #1 of `Infection\Mutat
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/PhpParser/FakeToken.php"
 code = "incompatible-parameter-type"
 message = 'Parameter `$kind` of `Infection\Tests\PhpParser\FakeToken::is()` expects type `array<array-key, int|string>|int|string` but parent `PhpToken::is()` expects type `array<array-key, mixed>|int|string`'
@@ -5056,14 +4990,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
 code = "docblock-type-mismatch"
-message = 'Docblock type `PhpParser\Node|array<array-key, PhpParser\Node>` for parameter `$node` is incompatible with native type `PhpParser\Node\Scalar\LNumber|array<array-key, mixed>`.'
+message = 'Docblock type `PhpParser\Node|array<array-key, PhpParser\Node>` for parameter `$node` is incompatible with native type `PhpParser\Node\Scalar\Int_|array<array-key, mixed>`.'
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -2305,18 +2305,6 @@ message = 'Potentially unhandled exception `Infection\Mutator\InvalidMutator` in
 count = 1
 
 [[issues]]
-file = "src/Mutator/Number/DecrementInteger.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Number/IncrementInteger.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
 file = "src/Mutator/Number/OneZeroFloat.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\DNumber` is deprecated and should no longer be used.'
@@ -2326,12 +2314,6 @@ count = 2
 file = "src/Mutator/Operator/SpreadOneItem.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Expr\ArrayItem` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/Operator/SpreadOneItem.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
 count = 1
 
 [[issues]]
@@ -2413,21 +2395,9 @@ message = "Invalid type for left operand."
 count = 2
 
 [[issues]]
-file = "src/Mutator/ReturnValue/ArrayOneItem.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 3
-
-[[issues]]
 file = "src/Mutator/ReturnValue/FloatNegation.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\DNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "src/Mutator/ReturnValue/IntegerNegation.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
 count = 1
 
 [[issues]]
@@ -6790,12 +6760,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 12
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
@@ -6803,7 +6767,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\Int_}`.'
 count = 5
 
 [[issues]]
@@ -6922,12 +6886,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
@@ -6935,7 +6893,7 @@ count = 1
 [[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
+message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\Int_}`.'
 count = 2
 
 [[issues]]
@@ -8092,12 +8050,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php"
 code = "imprecise-type"
 message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
@@ -8476,14 +8428,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
-code = "deprecated-class"
-message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
 code = "docblock-type-mismatch"
-message = 'Docblock type `PhpParser\Node|array<array-key, PhpParser\Node>` for parameter `$node` is incompatible with native type `PhpParser\Node\Scalar\LNumber|array<array-key, mixed>`.'
+message = 'Docblock type `PhpParser\Node|array<array-key, PhpParser\Node>` for parameter `$node` is incompatible with native type `PhpParser\Node\Scalar\Int_|array<array-key, mixed>`.'
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -950,12 +950,6 @@ count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
-code = "non-existent-class"
-message = 'Class `Infection\FileSystem\DummyFileSystem` not found.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
 code = "template-constraint-violation"
 message = "Argument type mismatch for template `T`."
 count = 1
@@ -2305,6 +2299,18 @@ message = 'Potentially unhandled exception `Infection\Mutator\InvalidMutator` in
 count = 1
 
 [[issues]]
+file = "src/Mutator/Number/DecrementInteger.php"
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
+count = 1
+
+[[issues]]
+file = "src/Mutator/Number/IncrementInteger.php"
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
+count = 1
+
+[[issues]]
 file = "src/Mutator/Number/OneZeroFloat.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\DNumber` is deprecated and should no longer be used.'
@@ -2314,6 +2320,12 @@ count = 2
 file = "src/Mutator/Operator/SpreadOneItem.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Expr\ArrayItem` is deprecated and should no longer be used.'
+count = 1
+
+[[issues]]
+file = "src/Mutator/Operator/SpreadOneItem.php"
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
 count = 1
 
 [[issues]]
@@ -2395,9 +2407,21 @@ message = "Invalid type for left operand."
 count = 2
 
 [[issues]]
+file = "src/Mutator/ReturnValue/ArrayOneItem.php"
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
+count = 3
+
+[[issues]]
 file = "src/Mutator/ReturnValue/FloatNegation.php"
 code = "deprecated-class"
 message = 'Class `PhpParser\Node\Scalar\DNumber` is deprecated and should no longer be used.'
+count = 1
+
+[[issues]]
+file = "src/Mutator/ReturnValue/IntegerNegation.php"
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
 count = 1
 
 [[issues]]
@@ -3883,1020 +3907,6 @@ message = 'Potentially unhandled exception `Infection\FileSystem\Finder\Exceptio
 count = 1
 
 [[issues]]
-file = "tests/autoloaded/mutator-code-samples/ReturnTypes.php"
-code = "missing-return-type"
-message = "Function `selfReturnWithoutReturnType` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/ReturnTypes.php"
-code = "missing-return-type"
-message = "Function `withoutReturnType` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/ReturnTypes.php"
-code = "missing-template-parameter"
-message = "Too few template arguments for `ArrayObject`: expected at least 2, but found 0."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "invalid-assignment"
-message = "Invalid target for assignment."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "invalid-callable"
-message = "Expression of type `mixed` cannot be called as a function or method."
-count = 26
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "invalid-member-selector"
-message = "Invalid type `mixed` used as a member selector; a string is expected."
-count = 22
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "invalid-method-access"
-message = "Attempting to access a method on a non-object type (`string('Class')`)."
-count = 2
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-array-access"
-message = "Unsafe array access on type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 13
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-method-access"
-message = "Attempting to access a method on a non-object type (`mixed`)."
-count = 9
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-operand"
-message = "Left operand in `<` comparison has `mixed` type."
-count = 3
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-operand"
-message = "Left operand in `==` comparison has `mixed` type."
-count = 6
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-operand"
-message = "Left operand in `>` comparison has `mixed` type."
-count = 6
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-operand"
-message = "Right operand in `<` comparison has `mixed` type."
-count = 4
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-operand"
-message = "Right operand in `==` comparison has `mixed` type."
-count = 5
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-operand"
-message = "Right operand in `>` comparison has `mixed` type."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "mixed-property-access"
-message = "Attempting to access a property on a non-object type (`mixed`)."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "non-existent-function"
-message = "Function `a string can be a function as well` could not be found."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "non-existent-function"
-message = "Function `fake_function` could not be found."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "non-existent-function"
-message = "Function `func` could not be found."
-count = 12
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "non-existent-function"
-message = "Function `function` could not be found."
-count = 2
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "non-existent-function"
-message = "Function `it can also be in between brackets` could not be found."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-code-samples/VariableFunctionNames.php"
-code = "undefined-variable"
-message = "Undefined variable: `$somethign`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayItemRemoval/does-not-mutate-array-in-attribute.php"
-code = "missing-return-type"
-message = "Function `method` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayItemRemoval/does-not-mutate-array-in-attribute.php"
-code = "non-existent-attribute-class"
-message = 'Attribute class `ArrayItemRemoval_Array_In_Attribute\Groups` not found or could not be autoloaded.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-function-call.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getCollection` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-function-call.php"
-code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `ArrayOneItem_FunctionCall\Test::getCollection`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-function-call.php"
-code = "non-existent-function"
-message = 'Could not find definition for function `ArrayOneItem_FunctionCall\foo` (also tried as `foo` in a broader scope).'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-function-variable-call.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getCollection` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-method-call.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getCollection` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-method-call.php"
-code = "mixed-return-statement"
-message = 'Could not infer a precise return type for function `ArrayOneItem_MethodCall\Test::getCollection`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-method-call.php"
-code = "non-existent-method"
-message = 'Method `foo` does not exist on type `ArrayOneItem_MethodCall\Test`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-nullable-array.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getCollection` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/does-not-mutate-raw-array.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getCollection` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ArrayOneItem/mutates-not-nullable-array.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getCollection` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/CastBool/bool-method.php"
-code = "too-few-arguments"
-message = "Too few arguments provided for function `preg_match`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/EqualIdentical/identical-intersection-type.php"
-code = "missing-return-type"
-message = "Function `compareFoos` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/EqualIdentical/identical-intersection-type.php"
-code = "unused-statement"
-message = "Expression has no effect as a statement"
-count = 2
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/EqualIdentical/non-numeric-non-empty-class-const.php"
-code = "missing-constant-type"
-message = "Class constant `BAR` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/EqualIdentical/non-numeric-non-empty-class-const.php"
-code = "missing-parameter-type"
-message = "Parameter `$x` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/EqualIdentical/non-numeric-non-empty-class-const.php"
-code = "missing-return-type"
-message = "Function `doFoo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/EqualIdentical/non-numeric-non-empty-class-const.php"
-code = "mixed-operand"
-message = "Left operand in `==` comparison has `mixed` type."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-contains-another-func-and-null-allowed.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-contains-another-func-and-null-allowed.php"
-code = "mixed-return-statement"
-message = "Could not infer a precise return type for function `{closure:tests/autoloaded/mutator-fixtures/FunctionCall/fc-contains-another-func-and-null-allowed.php:9:14}`. Saw type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-contains-another-func-and-null-is-not-allowed.php"
-code = "mixed-return-statement"
-message = "Could not infer a precise return type for function `{closure:tests/autoloaded/mutator-fixtures/FunctionCall/fc-contains-another-func-and-null-is-not-allowed.php:9:14}`. Saw type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-mutates-return-typehint-fqcn-allows-null.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `FunctionCall_ReturnTypehintFqcnAllowsNull\Test::test`: expected `DateTime|null`, but found `non-negative-int`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-mutates-without-typehint.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-not-mutates-return-typehint-fqcn-does-not-allow-null.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `FunctionCall_ReturnTypehintFqcnDoesNotAllowNull\Test::test`: expected `DateTime`, but found `non-negative-int`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/FunctionCall/fc-not-mutates-with-not-nullable-typehint.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `FunctionCall_NotMutatesWithNotNullableTypehint\Test::test`: expected `bool`, but found `non-negative-int`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-contains-another-func-and-null-allowed.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-contains-another-func-and-null-allowed.php"
-code = "mixed-return-statement"
-message = "Could not infer a precise return type for function `{closure:tests/autoloaded/mutator-fixtures/NewObject/no-contains-another-func-and-null-allowed.php:11:14}`. Saw type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-contains-another-func-and-null-is-not-allowed.php"
-code = "mixed-return-statement"
-message = "Could not infer a precise return type for function `{closure:tests/autoloaded/mutator-fixtures/NewObject/no-contains-another-func-and-null-is-not-allowed.php:11:14}`. Saw type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-mutates-scalar-return-typehint-allows-null.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `NewObject_ScalarReturnTypehintsAllowsNull\Test::test`: expected `int|null`, but found `stdClass`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-mutates-without-typehint.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-not-mutates-anonymous-class.php"
-code = "missing-return-type"
-message = "Function `getFoo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-not-mutates-anonymous-class.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/NewObject/no-not-mutates-scalar-return-typehint-does-not-allow-null.php"
-code = "invalid-return-statement"
-message = 'Invalid return type for function `NewObject_ScalarReturnTypehintFqcnDoesNotAllowNull\Test::test`: expected `int`, but found `stdClass`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-abstract-class-protected-method.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-abstract-class-protected-method.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-abstract-class-protected-method.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-abstract.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-class.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-class.php"
-code = "unused-method"
-message = "Method `foo()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-class.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-class.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php"
-code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `ProtectedVisibilityFinal\TestEnum::foo`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php"
-code = "unused-method"
-message = "Method `foo()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final-enum.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final.php"
-code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `ProtectedVisibilityFinal\Test::foo`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-final.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-non-same-method-parent.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-non-same-method-parent.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-one-class.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-one-class.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-one-class.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-same-method-abstract.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-same-method-abstract.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-same-method-grandparent.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-same-method-parent.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-static.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-static.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/ProtectedVisibility/pv-static.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__call.php"
-code = "missing-parameter-type"
-message = "Parameter `$n` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__call.php"
-code = "missing-parameter-type"
-message = "Parameter `$v` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__call.php"
-code = "missing-return-type"
-message = "Function `__call` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__call.php"
-code = "unused-parameter"
-message = "Parameter `$n` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__call.php"
-code = "unused-parameter"
-message = "Parameter `$v` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__callStatic.php"
-code = "missing-parameter-type"
-message = "Parameter `$n` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__callStatic.php"
-code = "missing-parameter-type"
-message = "Parameter `$v` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__callStatic.php"
-code = "missing-return-type"
-message = "Function `__callStatic` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__callStatic.php"
-code = "unused-parameter"
-message = "Parameter `$n` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__callStatic.php"
-code = "unused-parameter"
-message = "Parameter `$v` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__debugInfo.php"
-code = "missing-return-type"
-message = "Function `__debugInfo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__get.php"
-code = "missing-parameter-type"
-message = "Parameter `$n` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__get.php"
-code = "missing-return-type"
-message = "Function `__get` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__get.php"
-code = "unused-parameter"
-message = "Parameter `$n` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__invoke.php"
-code = "missing-return-type"
-message = "Function `__invoke` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__isset.php"
-code = "missing-parameter-type"
-message = "Parameter `$n` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__isset.php"
-code = "missing-return-type"
-message = "Function `__isset` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__isset.php"
-code = "unused-parameter"
-message = "Parameter `$n` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__set.php"
-code = "missing-parameter-type"
-message = "Parameter `$n` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__set.php"
-code = "missing-parameter-type"
-message = "Parameter `$v` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__set.php"
-code = "missing-return-type"
-message = "Function `__set` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__set.php"
-code = "unused-parameter"
-message = "Parameter `$n` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__set.php"
-code = "unused-parameter"
-message = "Parameter `$v` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__toString.php"
-code = "missing-return-type"
-message = "Function `__toString` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__unset.php"
-code = "missing-parameter-type"
-message = "Parameter `$n` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__unset.php"
-code = "missing-return-type"
-message = "Function `__unset` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-__unset.php"
-code = "unused-parameter"
-message = "Parameter `$n` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-abstract.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-final.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-final.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-final.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-interface.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-non-abstract-in-abstract-class.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-non-abstract-in-abstract-class.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-non-abstract-in-abstract-class.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-non-same-method-parent.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-non-same-method-parent.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-not-set.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-one-class.php"
-code = "invalid-return-statement"
-message = 'Cannot return a non-referenceable value from function `PublicVisibilityOneClass\Test::foo`.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-one-class.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-one-class.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-one-class.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-protected-parent.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-same-method-abstract.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-same-method-abstract.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-same-method-abstract.php"
-code = "unused-method"
-message = "Method `bar()` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-same-method-any-interface.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-same-method-grandparent.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-same-method-interface.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-same-method-parent.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-static.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-static.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/PublicVisibility/pv-static.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-anonymous-class-inside-class-that-extends.php"
-code = "missing-return-type"
-message = "Function `createAnonymousClass` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-anonymous-class-inside-class-that-extends.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-anonymous-class-inside-class-that-extends.php"
-code = "unused-statement"
-message = "Expression has no effect as a statement"
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-anonymous-class-inside-class.php"
-code = "missing-return-type"
-message = "Function `createAnonymousClass` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-anonymous-class-inside-class.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-anonymous-class-inside-class.php"
-code = "unused-statement"
-message = "Expression has no effect as a statement"
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-anonymous-class.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-class-method.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-closure.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-function.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-function.php"
-code = "unused-parameter"
-message = "Parameter `$a` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-plain-function-in-class.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-plain-function-in-class.php"
-code = "missing-return-type"
-message = "Function `foo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-plain-function-in-class.php"
-code = "unused-statement"
-message = "Expression has no effect as a statement"
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-plain-function-in-closure.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-plain-function-in-closure.php"
-code = "unused-parameter"
-message = "Parameter `$b` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-inside-plain-function-in-closure.php"
-code = "unused-statement"
-message = "Expression has no effect as a statement"
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag-with-attributes.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag-with-attributes.php"
-code = "non-existent-attribute-class"
-message = 'Attribute class `InfectionReflectionPartOfSignatureWithAttributes\CustomAttribute` not found or could not be autoloaded.'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag-with-attributes.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag-with-attributes.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag.php"
-code = "missing-parameter-type"
-message = "Parameter `$test` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag.php"
-code = "unused-parameter"
-message = "Parameter `$param` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/Reflection/rv-part-of-signature-flag.php"
-code = "unused-parameter"
-message = "Parameter `$test` is never used."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/This/this-return-types.php"
-code = "missing-return-type"
-message = "Function `bar` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/This/this-return-types.php"
-code = "missing-return-type"
-message = "Function `baz` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/This/this-return-types.php"
-code = "missing-return-type"
-message = "Function `boo` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/This/this-return-types.php"
-code = "missing-return-type"
-message = "Function `other` is missing a return type hint."
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/This/this-return-types.php"
-code = "non-existent-function"
-message = 'Could not find definition for function `ThisReturnTypes\this` (also tried as `this` in a broader scope).'
-count = 1
-
-[[issues]]
-file = "tests/autoloaded/mutator-fixtures/This/this_return-this.php"
-code = "missing-return-type"
-message = "Function `test` is missing a return type hint."
-count = 1
-
-[[issues]]
 file = "tests/benchmark/AstProcessing/AstProcessingBench.php"
 code = "invalid-callable"
 message = "Expression of type `mixed` cannot be called as a function or method."
@@ -5131,27 +4141,9 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 3
 
 [[issues]]
-file = "tests/phpunit/AutoReview/BuildConfigYmlTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesYamlFilesForTesting` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/AutoReview/ConcreteClassReflector.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `ReflectionClass::__construct`: expected `('T.reflectionclass extends object)|class-string<'T.reflectionclass extends object>`, but possibly received `string`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `rootTestTargetProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `subTargetProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -5165,42 +4157,6 @@ file = "tests/phpunit/AutoReview/Makefile/MakefileTest.php"
 code = "possible-method-access-on-null"
 message = "Attempting to call a method on `null`."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `concreteMutatorClassesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configurableMutatorClassesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutatorClassesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideConcreteMutatorClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideConfigurableMutatorClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideMutatorClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/AutoReview/Mutator/MutatorProvider.php"
@@ -5293,30 +4249,6 @@ message = "This condition (type `true`) will always evaluate to true."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/DocBlockParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `docBlocksProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideSourceClasses` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/AutoReview/ProjectCode/ProjectCodeProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `sourceClassProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/BenchmarkSmokeTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideBenchmarks` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/CI/MemoizedCiDetectorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Tests\CI\ConfigurableEnv::setVariables`: expected `array<string, false|string>`, but possibly received `array{'TRAVIS': true}`.'''
@@ -5335,117 +4267,9 @@ message = 'Potential static method call on interface `Infection\Command\Option\C
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `astProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/DumpAstCommand/DumpAstCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidFileProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Debug/MockTeamCityCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidTimeValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedFilesCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `commandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Git/GitChangedLinesCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `commandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `failingCommandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `successfulCommandExecutionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Command/MakeCustomMutatorCommandTest.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$fileSystemMock`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/Option/PathsArgumentTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesDotsPerRow` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesGetStringOption` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesIgnoreMsiWithNoMutations` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesMaxTimeouts` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesNumberOfShownMutations` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesThreadCount` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesTimeoutsAsEscaped` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesUsesGitHubLogger` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Command/RunCommandHelperTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Resource\Processor\DummyCpuCoresCountProvider` not found.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Config/Guesser/PhpUnitPathGuesserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesJsonComposerAndLocations` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -5497,150 +4321,6 @@ message = "Reference created from a previously undefined variable `$output`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Config/ValueProvider/ExcludeDirsProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `excludeDirsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Config/ValueProvider/PCOVDirectoryProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `sourceDirectoryPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Mutator\IgnoreMutator::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationBuilder.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "no-value"
-message = 'Argument #1 passed to method `Infection\Tests\Configuration\ConfigurationFactory\ConfigurationFactoryScenario::withCpuCoresCountProvider` has type `never`, meaning it cannot produce a value.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "no-value"
-message = 'Argument #5 passed to method `Infection\Configuration\ConfigurationFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\DummyCiDetector` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Mutator\CustomMutator` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Resource\Processor\DummyCpuCoresCountProvider` not found.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Configuration/ConfigurationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `staticAnalysisToolOptionsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/LogsBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `logsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/MagoTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `basePathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/PhpStanTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `basePathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/PhpUnitTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `basePathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Entry/StrykerConfigTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `branch_names_to_be_matched` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/PositionalPathsClassifier/PositionalPathsClassifierTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideClassifiablePaths` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/PositionalPathsClassifier/PositionalPathsClassifierTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideInvalidPaths` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ProjectDirectoryProvider/ChainProjectDirectoryProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providerProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/ProjectDirectoryProvider/EnvironmentVariableBasedProjectDirectoryProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `directoryProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/InvalidFileTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `jsonErrorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/InvalidSchemaTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configWithErrorsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configurationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideRawConfig` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `Infection\Configuration\Schema\SchemaConfigurationFactory::create`: expected `stdClass`, but found `mixed`.'
@@ -5671,57 +4351,15 @@ message = 'Too few arguments provided for method `Infection\Configuration\Schema
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFileTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidConfigContentsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaConfigurationLoaderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configurationPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaValidatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `filterToStringProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Configuration/SourceFilter/PlainFilterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/ApplicationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideNonCommandArguments` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Console/E2ETest.php"
 code = "implicit-to-string-cast"
 message = 'Implicit conversion to `string` for left operand via `Symfony\Component\Finder\SplFileInfo::__toString()`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/E2ETest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `e2eTestSuiteDataProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -5761,30 +4399,6 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 9
 
 [[issues]]
-file = "tests/phpunit/Console/Input/MsiParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/Input/MsiParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `precisionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/Input/MsiParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `validValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Console/LogVerbosityTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `convertedLogVerbosityProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Container/Builder/IndexXmlCoverageParserBuilderTest.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\Tests\Container\Builder\IndexXmlCoverageParserBuilderTest::getIsSourceFiltered`. Saw type `mixed`.'
@@ -5794,18 +4408,6 @@ count = 1
 file = "tests/phpunit/Container/ContainerTest.php"
 code = "avoid-catching-error"
 message = "Avoid catching 'Error' class instances."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideExpectedConcreteServicesWithReflection` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Container/ContainerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideServicesWithReflection` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -5821,51 +4423,9 @@ message = "This member selector uses a non-literal string type (`string`); its s
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Differ/ChangedLinesRangeTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `rangeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/DifferTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `diffProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/DifferTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `diffStringProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Differ/DifferTest.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #2 of `Infection\Tests\TestingUtility\PHPUnit\DataProviderFactory::takeArguments`: expected `iterable<array-key, array<array-key, mixed>>`, but provided type `iterable<mixed, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/UnifiedDiffOutputBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `diffProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/UnifiedDiffOutputBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidDiffProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Differ/UnifiedDiffOutputBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `unifiedDiffProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Environment/BuildContextResolverTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideBlankOrEmptyString` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -5876,87 +4436,21 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "impossible-assignment"
-message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
 code = "impossible-type-comparison"
-message = "Impossible type assertion: `$userSubscriber->count` of type `null` can never be `int(0)`."
+message = "Impossible type assertion: `$userSubscriber->count` of type `int(0)` can never be `int(2)`."
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "invalid-property-access"
-message = "Attempting to access a property on a non-object type (`never`)."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::addSubscriber` has type `never`, meaning it cannot produce a value.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\EventDispatcher\SyncEventDispatcher::dispatch` has type `never`, meaning it cannot produce a value.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `PHPUnit\Framework\Assert::assertSame` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\UnknownEventSubscriber` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\UserEventSubscriber` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\UserWasCreatedCounterSubscriber` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/EventDispatcher/SyncEventDispatcherTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\UserWasCreated` not found.'
-count = 3
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "impossible-assignment"
 message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
-code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
 code = "no-value"
-message = 'Argument #2 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
-code = "no-value"
-message = 'Argument #3 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
+message = 'Argument #1 passed to method `Infection\Tests\Fixtures\Event\IONullSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
@@ -5965,81 +4459,9 @@ message = 'Class `Infection\Tests\Fixtures\Console\FakeOutput` not found.'
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\DummySubscriberFactory` not found.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/ChainSubscriberFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\IONullSubscriber` not found.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`).'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `PHPUnit\Framework\Assert::assertCount`: expected `Countable|iterable<mixed, mixed>`, but found `mixed`.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "no-value"
-message = 'Argument #1 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "no-value"
-message = 'Argument #3 passed to method `Infection\Event\Subscriber\ChainSubscriberFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\DummySubscriberFactory` not found.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Event/Subscriber/SubscriberRegistererTest.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #1 of `Infection\Event\Subscriber\SubscriberRegisterer::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\SubscriberCollectEventDispatcher)`.'
-count = 2
-
-[[issues]]
 file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
 code = "ambiguous-object-method-access"
 message = "Cannot statically verify method call on a generic `object` type."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesFinders` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -6062,194 +4484,26 @@ count = 4
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\Finder\MockRealPathFinder` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\Finder\MockRelativePathFinder` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/Iterator/RealPathFilterIteratorTest.php"
 code = "unknown-class-instantiation"
 message = "Cannot determine the concrete class for instantiation."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesMockSetup` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/StaticAnalysisToolExecutableFinderTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesMockSetup` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileNotFoundTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `multipleNonExistentPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileNotFoundTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nonExistentPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `multipleNonExistentPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nonExistentPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `multipleInvalidPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `multiplePathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `multipleInvalidPathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `multiplePathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/RootsFileOrDirectoryLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `pathsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidTmpDirProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/TmpDirProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `tmpDirProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `classNameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `classNamespaceProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `notTestClassNameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `notTestClassNamesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `sourceClassNameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/ClassNameTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `sourceClassNamesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `enumClassNameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `enumProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `noLongerAvailableValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Enum/EnumBucket/EnumBucketTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nonExistentValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -6271,105 +4525,9 @@ message = "Argument type mismatch for template `T`."
 count = 3
 
 [[issues]]
-file = "tests/phpunit/Framework/Enum/ImplodableEnum/ImplodableEnumTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `separatorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/Iterable/GeneratorFactory/GeneratorFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `iterableProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/StrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `cleanTrimLinesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/StrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `indentProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/StrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `toSystemLineEndingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/StrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `toUnixLineEndingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/StrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `trimLinesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Framework/StrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `utf8StringConversionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Framework/StrTest.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #2 of `Infection\Tests\TestingUtility\PHPUnit\DataProviderFactory::takeArguments`: expected `iterable<array-key, array<array-key, mixed>>`, but provided type `iterable<mixed, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `defaultGitBaseProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Git/CommandLineGitTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `gitChangedLinesRangesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialStaticAnalysisExecution/InitialStaticAnalysisExecutionLoggerFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `debugProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `debugProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `logProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/BasicConsoleLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideLogsInNormalVerbosity` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `outputMappingProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/Console/ConsoleLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valueToCastProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -6379,75 +4537,9 @@ message = "Parameter `$value` is missing a type hint."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `detectionStatusProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `totalMutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/ConsoleDotLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `unknownTotalProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `loggerProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Logger/MutationAnalysis/MutationAnalysisLoggerFactoryTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `PHPUnit\Framework\Assert::assertInstanceOf`: expected `class-string<'ExpectedType.phpunit\framework\assert::assertinstanceof() extends object>`, but possibly received `string`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/RemoveInternalBlankLinesTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `linesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityLoggerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `executionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `executionResultProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `messageProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TeamCityTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `startedProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TestSuiteTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `suiteProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Logger/MutationAnalysis/TeamCity/TestTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `caseProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -6463,18 +4555,6 @@ message = 'Class `Infection\Tests\Fixtures\Console\FakeOutput` not found.'
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Metrics/CalculatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsCalculatorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/CalculatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Metrics/CreateMutantExecutionResult.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #13 of `Infection\Mutant\MutantExecutionResult::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('<?php $a = 1;')>`.'''
@@ -6487,28 +4567,10 @@ message = '''Possible argument type mismatch for argument #14 of `Infection\Muta
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `exceptionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Metrics/MaxTimeoutsCheckerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `noExceptionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Metrics/MetricsCalculatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `resultsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php"
@@ -6542,62 +4604,14 @@ count = 4
 
 [[issues]]
 file = "tests/phpunit/MockedContainer.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$values` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/MockedContainer.php"
 code = "invalid-param-tag"
 message = "Could not resolve the type for the @param tag."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/DetectionStatusTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `detectionStatusProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantAssertionsTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutantProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutantBuilder` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationOnlyProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutant/MutantCodeFactoryTest.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #2 of `Infection\Tests\TestingUtility\PHPUnit\DataProviderFactory::takeArguments`: expected `iterable<array-key, array<array-key, mixed>>`, but provided type `iterable<mixed, mixed>` is less specific.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantCodePrinterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `statementsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutant/MutantExecutionResultAssertionsTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutantExecutionResultProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -6675,12 +4689,6 @@ Possible argument type mismatch for argument #4 of `Infection\Tests\Mutant\Mutan
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/MutantExecutionResultBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `executionResultProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutant/MutantFactoryTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #3 of `Infection\Mutant\Mutant::__construct`: expected `Later\Interfaces\Deferred<string>`, but possibly received `Later\Interfaces\Deferred<string('mutated code')>`.'''
@@ -6699,75 +4707,21 @@ message = '''Possible argument type mismatch for argument #5 of `Infection\Mutan
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutant/MutantTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `scenarioProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutation/FileMutationGenerator/FileMutationGeneratorTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\PhpParser\FakeNode` not found.'
-count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationAssertionsTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationAttributeKeysTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `attributesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutation/MutationBuilder.php"
 code = "less-specific-argument"
 message = 'Argument type mismatch for argument #6 of `Infection\Tests\Mutation\MutationBuilder::__construct`: expected `array<string, float|int|string>`, but provided type `array<array-key, float|int|string>` is less specific.'
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutation/MutationBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Mutator\IgnoreMutator::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutation/MutationGeneratorTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
+count = 12
 
 [[issues]]
 file = "tests/phpunit/Mutation/MutationTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\Int_}`.'
+message = 'Invalid argument type for argument #2 of `PhpParser\Node\Stmt\Namespace_::__construct`: expected `array<array-key, PhpParser\Node\Stmt>|null`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
 count = 5
 
 [[issues]]
@@ -6777,441 +4731,21 @@ message = 'Argument type mismatch for argument #5 of `Infection\Mutation\Mutatio
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/AssignmentEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/AssignmentTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/BitwiseAndTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/BitwiseNotTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/BitwiseOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/BitwiseXorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/DecrementTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/DivEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/DivisionTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/ExponentiationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/IncrementTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/MinusEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/MinusTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/ModEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/ModulusTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/MulEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/MultiplicationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/PlusEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
+count = 4
 
 [[issues]]
 file = "tests/phpunit/Mutator/Arithmetic/PlusTest.php"
 code = "invalid-argument"
-message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\Int_}`.'
+message = 'Invalid argument type for argument #1 of `PhpParser\Node\Expr\Array_::__construct`: expected `array<array-key, PhpParser\Node\ArrayItem>`, but found `list{PhpParser\Node\Scalar\LNumber}`.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/PowEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/RoundingFamilyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/ShiftLeftTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Arithmetic/ShiftRightTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/ArrayAllTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/ArrayAnyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/ArrayItemTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/EqualIdenticalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/FalseValueTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/InstanceOf_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalAndAllSubExprNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalAndNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalAndSingleSubExprNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalAndTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalLowerAndTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalLowerOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalNotTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrAllSubExprNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrSingleSubExprNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `bug2975Provider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `equalityMutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `instanceOfMutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutableSmallerAndGreaterMatrixMutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nonMutableSmallerAndGreaterMatrixMutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/LogicalOrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `smallerAndGreaterMatrixWithSameValueMutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/NotEqualNotIdenticalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/NotIdenticalNotEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `settingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Boolean/TrueValueConfigTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Boolean\TrueValueConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/TrueValueTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Boolean/Yield_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Cast/CastArrayTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Cast/CastBoolTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Cast/CastFloatTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Cast/CastIntTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Cast/CastObjectTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Cast/CastStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalBoundary/GreaterThanOrEqualToTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalBoundary/GreaterThanTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalBoundary/LessThanOrEqualToTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalBoundary/LessThanTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/EqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanNegotiationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/GreaterThanOrEqualToNegotiationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/IdenticalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/LessThanNegotiationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/LessThanOrEqualToNegotiationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/NotEqualTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ConditionalNegotiation/NotIdenticalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/DefinitionTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutatorsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/DefinitionTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -7228,62 +4762,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `settingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathConfigTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Extensions\BCMathConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$settings` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForBinaryOperator` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForComparision` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForPowerModulo` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForPowerOperator` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForSquareRoot` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/BCMathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideCasesWhereMutatorShouldNotApply` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -7294,158 +4774,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `settingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringConfigTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\Extensions\MBStringConfig::__construct`: expected `array<string, bool>`, but possibly received `array{'foo': string('bar')}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForChr` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForConvertCase` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForOrd` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForParseStr` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForSendMail` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrCut` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrIPos` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrIStr` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrPos` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrRChr` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrRPos` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrRiPos` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrSplit` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrStr` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrToLower` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForStrToUpper` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForSubStrCount` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProviderForSubStr` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Extensions/MBStringTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/FunctionSignature/ProtectedVisibilityTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `blacklistedProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/FunctionSignature/PublicVisibilityTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreConfigTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `ignoredValuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/IgnoreConfigTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nonIgnoredValuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -7453,30 +4783,6 @@ file = "tests/phpunit/Mutator/IgnoreMutatorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #2 of `Infection\Mutator\IgnoreMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\ignoremutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 4
-
-[[issues]]
-file = "tests/phpunit/Mutator/Loop/DoWhileTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Loop/For_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Loop/Foreach_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Loop/While_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorCategoryTest.php"
@@ -7560,18 +4866,6 @@ count = 1
 file = "tests/phpunit/Mutator/MutatorFactoryTest.php"
 code = "possibly-invalid-argument"
 message = 'Possible argument type mismatch for argument #3 of `Infection\Tests\Mutator\MutatorFactoryTest::createBoolNode`: expected `Infection\Reflection\ClassReflection`, but possibly received `Infection\Reflection\ClassReflection|PHPUnit\Framework\MockObject\MockObject`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutatorInputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorParserTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\Mutator\FakeMutator` not found.'
 count = 1
 
 [[issues]]
@@ -7660,20 +4954,8 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutatorWithCodeCaseProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/MutatorRobustnessTest.php"
 code = "possibly-invalid-argument"
 message = 'Possible argument type mismatch for argument #1 of `Infection\Mutator\MutatorFactory::create`: expected `array<class-string<Infection\Mutator\Mutator<PhpParser\Node>&Infection\Mutator\ConfigurableMutator<PhpParser\Node>>, array<array-key, mixed>>`, but possibly received `non-empty-array<class-string, array{}>`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/NodeAttributesTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -7681,174 +4963,6 @@ file = "tests/phpunit/Mutator/NoopMutatorTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Infection\Mutator\NoopMutator::__construct`: expected `Infection\Mutator\Mutator<('TNode.infection\mutator\noopmutator extends PhpParser\Node)>`, but possibly received `PHPUnit\Framework\MockObject\MockObject&Infection\Mutator\Mutator`.'''
 count = 3
-
-[[issues]]
-file = "tests/phpunit/Mutator/Nullify/ArrayFindKeyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Nullify/ArrayFindTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Nullify/ArrayFirstTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Nullify/ArrayLastTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Number/DecrementIntegerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Number/IncrementIntegerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Number/OneZeroFloatTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/AssignCoalesceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/Break_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/Catch_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/CoalesceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/ConcatTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/Continue_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/ElseIfNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/Finally_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/IfNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/NullSafeMethodCallTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/NullSafePropertyCallTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/SpreadAssignmentTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/SpreadOneItemTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/SpreadRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/TernaryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Operator/Throw_Test.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getProfiles` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `implementedMutatorFileAndClassProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `implementedMutatorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutatorNameAndClassProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `profileProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListProvider.php"
@@ -7894,12 +5008,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Mutator/ProfileListTest.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$profileOrMutators` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ProfileListTest.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #2 of `in_array`: expected `array<array-key, ('V.in_array() extends mixed)>`, but found `mixed`."
 count = 1
@@ -7911,45 +5019,9 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Regex/PregMatchMatchesTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Regex/PregMatchRemoveCaretTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideMutationCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Regex/PregMatchRemoveDollarTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideMutationCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Regex/PregMatchRemoveFlagsTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideMutationCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Regex/PregQuoteTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
 code = "avoid-catching-error"
 message = "Avoid catching 'Error' class instances."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalConfigTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `settingsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -7965,441 +5037,9 @@ message = '''Possible argument type mismatch for argument #1 of `Infection\Mutat
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Mutator/Removal/ArrayItemRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/CatchBlockRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/CloneRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/ConcatOperandRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/FunctionCallRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/MatchArmRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/MethodCallRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/ReturnRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `doesNotMutateWithReturnType` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/ReturnRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutatesWithReturnType` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/ReturnRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Removal/SharedCaseRemovalTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/ArrayOneItemTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/FloatNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/FunctionCallTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/NewObjectTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/ThisTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/ReturnValue/YieldValueTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Sort/SpaceshipTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/SyntaxErrorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayChangeKeyCaseTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayChunkTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayColumnTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayCombineTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffAssocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffKeyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUassocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayDiffUkeyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayFilterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayFlipTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectAssocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectKeyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUassocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayIntersectUkeyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayKeysTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayMapTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeRecursiveTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayMergeTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayPadTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayReduceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceRecursiveTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayReplaceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayReverseTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArraySliceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArraySpliceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffAssocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayUdiffUassocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectAssocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayUintersectUassocTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayUniqueTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapArrayValuesTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapFinallyTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapLcFirstTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapLtrimTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapRtrimTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapStrIreplaceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapStrRepeatTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapStrReplaceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapStrRevTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapStrShuffleTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapStrToLowerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapStrToUpperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapSubstrTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapTrimTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapUcFirstTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Unwrap/UnwrapUcWordsTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/ReturnTypeHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nullReturnProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/ReturnTypeHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `specificReturnTypeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Mutator/Util/ReturnTypeHelperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `voidReturnTypeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
 count = 1
 
 [[issues]]
@@ -8410,32 +5050,20 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/FakeTokenTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `methodProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/FakeTokenTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/PhpParser/FileParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `fileToParserProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
+file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
+code = "deprecated-class"
+message = 'Class `PhpParser\Node\Scalar\LNumber` is deprecated and should no longer be used.'
+count = 3
 
 [[issues]]
 file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
 code = "docblock-type-mismatch"
-message = 'Docblock type `PhpParser\Node|array<array-key, PhpParser\Node>` for parameter `$node` is incompatible with native type `PhpParser\Node\Scalar\Int_|array<array-key, mixed>`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/MutatedNodeTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
+message = 'Docblock type `PhpParser\Node|array<array-key, PhpParser\Node>` for parameter `$node` is incompatible with native type `PhpParser\Node\Scalar\LNumber|array<array-key, mixed>`.'
 count = 1
 
 [[issues]]
@@ -8464,36 +5092,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `codeWithDefaultConfigurationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `decoratedNodesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodesWithAttributesWhichMayCauseCircularDependenciesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `resolvedNameAttributeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `showLineNumbersProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeDumper/NodeDumper/NodeDumperTest.php"
 code = "invalid-argument"
 message = '''Invalid argument type for argument #1 of `Infection\Tests\PhpParser\NodeDumper\NodeDumper\NodeDumperScenario::forNode`: expected `PhpParser\Node|list<PhpParser\Node>`, but found `array{0: string('Foo'), 1: string('Bar'), 'Key': string('FooBar')}`.'''
 count = 1
@@ -8506,146 +5104,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `visitorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
 code = "invalid-return-statement"
 message = 'Invalid return type for function `Infection\Tests\PhpParser\NodeTraverserFactoryTest::getVisitorClassNames`: expected `list<class-string<PhpParser\NodeVisitor>>`, but found `list<string>`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "no-value"
-message = 'Argument #1 passed to method `Infection\PhpParser\NodeTraverserFactory::createMutationTraverser` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\PhpParser\FakeVisitor` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\PhpParser\FakeVisitor` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/NodeTraverserFactoryTest.php"
-code = "possibly-invalid-argument"
-message = '''Possible argument type mismatch for argument #2 of `Infection\Tests\PhpParser\NodeTraverserFactoryTest::assertTraverserVisitorsAre`: expected `list<class-string<PhpParser\NodeVisitor>>`, but possibly received `list{class-string('PhpParser\NodeVisitor\CloningVisitor'), class-string('Infection\Tests\Fixtures\PhpParser\FakeVisitor')}`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddIdToTraversedNodesVisitor/AddIdToTraversedNodesVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/AddTestsVisitor/AddTestsVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `scenarioProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/EnrichmentTraverseIntegrationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/ExcludeIgnoredNodesVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeIgnoredNodesVisitor/MarkAllButIneligibleNodesAsVisitedVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeNonMutableCodeVisitor/ExcludeNonMutableCodeVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `scenarioProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeUnchangedLinesVisitor/ExcludeUnchangedLinesVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ExcludeUntestedNodesVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/FullyQualifiedClassNameManipulatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/AbstractMethodIgnorerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/IgnoreNode/InterfaceIgnorerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/LabelNodesAsEligibleVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
 file = "tests/phpunit/PhpParser/Visitor/MarkTraversedNodesAsVisitedVisitor/MarkTraversedNodesAsVisitedVisitorTest.php"
 code = "mixed-return-statement"
 message = 'Could not infer a precise return type for function `Infection\Tests\PhpParser\Visitor\MarkTraversedNodesAsVisitedVisitor\MarkTraversedNodesAsVisitedVisitorTest::cloneNodes`. Saw type `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/MutatorVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesMutationCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/NextConnectingVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ParentConnectorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/ReflectionVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/PhpParser/Visitor/SkipIgnoredNodesVisitor/SkipIgnoredNodesVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -8667,118 +5133,10 @@ message = 'Cannot access protected method `Infection\Tests\PhpParser\Visitor\Vis
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "impossible-assignment"
-message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `timeoutDataProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/Runner/DryProcessRunnerTest.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #1 of `Infection\Process\Runner\DryProcessRunner::run`: expected `iterable<mixed, Infection\Process\MutantProcessContainer>`, but provided type `iterable<mixed, mixed>` is less specific.'
 count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`).'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #2 of `array_map`: expected `array<('K.array_map() extends array-key), object>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Process\Runner\InitialStaticAnalysisRunner::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialStaticAnalysisRunnerTest.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`).'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #1 of `end`: expected `array<array-key, ('T.end() extends mixed)>|object`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "mixed-argument"
-message = "Invalid argument type for argument #2 of `array_map`: expected `array<('K.array_map() extends array-key), object>`, but found `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "mixed-array-access"
-message = "Unsafe array access on type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "mixed-assignment"
-message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Process\Runner\InitialTestsRunner::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/InitialTestsRunnerTest.php"
-code = "possibly-invalid-argument"
-message = "Possible argument type mismatch for argument #1 of `array_filter`: expected `array<array-key, mixed>`, but possibly received `array<array-key, mixed>|list<mixed>|object`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "invalid-method-access"
-message = 'Attempting to access a method on a non-object type (`unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`).'
-count = 10
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -8788,20 +5146,14 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertAreSameEvents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but found `mixed`.'
+code = "less-specific-nested-argument-type"
+message = 'Argument type mismatch for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertAreSameEvents`: expected `array<array-key, Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutantProcessWasFinished|Infection\Event\Events\MutationAnalysis\MutationEvaluation\MutationEvaluationWasStarted|Infection\Event\Events\MutationAnalysis\MutationTestingWasFinished|Infection\Event\Events\MutationAnalysis\MutationTestingWasStarted>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 7
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertHasEvent`: expected `array<array-key, object>`, but found `mixed`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "mixed-argument"
-message = 'Invalid argument type for argument #2 of `PHPUnit\Framework\Assert::assertCount`: expected `Countable|iterable<mixed, mixed>`, but found `mixed`.'
+code = "less-specific-nested-argument-type"
+message = 'Argument type mismatch for argument #2 of `Infection\Tests\Process\Runner\MutationTestingRunnerTest::assertHasEvent`: expected `array<array-key, object>`, but provided type `array<array-key, mixed>` is less specific.'
 count = 1
 
 [[issues]]
@@ -8809,24 +5161,6 @@ file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
 count = 5
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "no-value"
-message = 'Argument #4 passed to method `Infection\Process\Runner\MutationTestingRunner::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Event\EventDispatcherCollector` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "non-existent-class-like"
-message = 'Cannot find class, interface, enum, or type alias `Infection\Tests\Fixtures\Event\EventDispatcherCollector`.'
-count = 1
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
@@ -8847,24 +5181,6 @@ message = 'Property `$mutationCount` does not exist on class `Infection\Event\Ev
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Process/Runner/MutationTestingRunnerTest.php"
-code = "possibly-invalid-argument"
-message = 'Possible argument type mismatch for argument #4 of `Infection\Process\Runner\MutationTestingRunner::__construct`: expected `Infection\Event\EventDispatcher\EventDispatcher`, but possibly received `unknown-ref(Infection\Tests\Fixtures\Event\EventDispatcherCollector)`.'
-count = 6
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "impossible-assignment"
-message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `threadCountProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "less-specific-nested-argument-type"
 message = 'Argument type mismatch for argument #1 of `Infection\Process\Runner\ParallelProcessRunner::run`: expected `iterable<mixed, Infection\Process\MutantProcessContainer>`, but provided type `iterable<mixed, mixed>` is less specific.'
@@ -8878,44 +5194,14 @@ count = 2
 
 [[issues]]
 file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "no-value"
-message = 'Argument #1 passed to method `Infection\Process\MutantProcessContainer::__construct` has type `never`, meaning it cannot produce a value.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Process\DummyMutantProcess` not found.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Process/Runner/ParallelProcessRunnerTest.php"
 code = "redundant-comparison"
 message = "Redundant `<=` comparison: left-hand side is always less than or equal to right-hand side."
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Process/ShellCommandLineExecutorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `commandProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/ClassReflectionTestCase.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideParentMethodCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reflection/ContainerReflection.php"
 code = "avoid-catching-error"
 message = "Avoid catching 'Error' class instances."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reflection/ContainerReflection.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getFactories` is imprecise, equivalent to `array<array-key, mixed>`."
 count = 1
 
 [[issues]]
@@ -8961,18 +5247,6 @@ message = "Redundant docblock type for variable `$returnTypeClassName`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Report/Framework/Writer/FileWriterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `contentsOrLinesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Report/Framework/Writer/StreamWriterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `streamProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Report/Framework/Writer/StreamWriterTest.php"
 code = "invalid-argument"
 message = '''Invalid argument type for argument #1 of `Infection\Report\Framework\Writer\StreamWriter::createForStream`: expected `string('php://stderr')|string('php://stdout')`, but found `string('/path/to/file.log')`.'''
@@ -8991,66 +5265,6 @@ message = '''Possible argument type mismatch for argument #14 of `Infection\Muta
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/DebugFileReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `reporterProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "no-value"
-message = 'Argument #3 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "no-value"
-message = 'Argument #4 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\FileSystem\DummyFileSystem` not found.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Logger\FakeLogger` not found.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileLocationReporter/FileLocationReporterTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter` not found.'
-count = 7
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "imprecise-type"
-message = "Type `array` in parameter `$expectedReporterClassNames` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "mixed-argument"
 message = "Invalid argument type for argument #2 of `array_map`: expected `array<('K.array_map() extends array-key), ('V.array_map() extends mixed)>`, but found `mixed`."
@@ -9066,60 +5280,6 @@ count = 2
 file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
 code = "mixed-return-statement"
 message = "Could not infer a precise return type for function `{closure:tests/phpunit/Reporter/FileReporterFactoryTest.php:362:13}`. Saw type `mixed`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "no-value"
-message = 'Argument #7 passed to method `Infection\Reporter\FileReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Logger\FakeLogger` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "no-value"
-message = 'Argument #3 passed to method `Infection\Reporter\FileReporter::__construct` has type `never`, meaning it cannot produce a value.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Reporter/FileReporterTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Reporter\DummyLineMutationTestingResultsReporter` not found.'
-count = 5
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubActionsLogTextFileReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `completeMetricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubActionsLogTextFileReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `emptyMetricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitHubAnnotationsReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/GitLabCodeQualityReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -9159,135 +5319,9 @@ message = 'Argument #2 of method `Infection\Mutant\MutantExecutionResult::__cons
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Reporter/Http/ResponseTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/Http/StrykerDashboardClientTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideResponseStatusCodes` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/JsonReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/PerMutatorReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/ShowMetricsReporter/ShowMetricsReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/ShowMutationsReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `resultsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
-code = "no-value"
-message = 'Argument #3 passed to method `Infection\Reporter\StrykerReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
-code = "no-value"
-message = 'Argument #4 passed to method `Infection\Reporter\StrykerReporterFactory::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\FakeCiDetector` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Logger\FakeLogger` not found.'
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Reporter/StrykerReporterFactoryTest.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `PHPUnit\Framework\Assert::assertInstanceOf`: expected `class-string<'ExpectedType.phpunit\framework\assert::assertinstanceof() extends object>`, but possibly received `string`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/SummaryFileReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/SummaryJsonReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `metricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/TextFileReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `completeMetricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Reporter/TextFileReporterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `emptyMetricsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Resource\Listener\PerformanceLoggerSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "no-value"
-message = 'Argument #3 passed to method `Infection\Resource\Listener\PerformanceLoggerSubscriber::__construct` has type `never`, meaning it cannot produce a value.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Resource\Memory\FakeMemoryFormatter` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Listener/PerformanceLoggerSubscriberTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\Resource\Time\FakeTimeFormatter` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryFormatterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `bytesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterEnvironmentTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `memoryLimitProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -9297,63 +5331,9 @@ message = "Too few arguments provided for method `ReflectionProperty::setValue`.
 count = 2
 
 [[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "impossible-assignment"
-message = "Invalid assignment: the right-hand side has type `never` and cannot produce a value."
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `memoryLimitProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "no-value"
-message = 'Argument #2 passed to method `Infection\Resource\Memory\MemoryLimiter::limitMemory` has type `never`, meaning it cannot produce a value.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Resource/Memory/MemoryLimiterTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\TestFramework\FakeAwareAdapter` not found.'
-count = 3
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/StopwatchTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `timeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Resource/Time/StopwatchTest.php"
 code = "possibly-invalid-argument"
 message = "Possible argument type mismatch for argument #1 of `usleep`: expected `non-negative-int`, but possibly received `int`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/TimeFormatterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `hoursProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/TimeFormatterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `minutesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/TimeFormatterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `secondsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Resource/Time/TimeFormatterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `timeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -9370,18 +5350,6 @@ count = 3
 
 [[issues]]
 file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `filteredFilesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `sourceFilesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/BasicSourceCollector/BasicSourceCollectorTest.php"
 code = "less-specific-argument"
 message = 'Argument type mismatch for argument #1 of `Infection\Tests\Source\Collector\BasicSourceCollector\BasicSourceCollectorTest::normalizePaths`: expected `array<string, SplFileInfo>`, but provided type `array<array-key, SplFileInfo>` is less specific.'
 count = 1
@@ -9393,93 +5361,15 @@ message = 'Possible argument type mismatch for argument #2 of `Infection\Source\
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Collector/LazySourceCollectorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `decoratedCollectorProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Collector/SourceCollectorFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `sourceFilterProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Exception/NoSourceFoundTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `changedLinesDiffProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Exception/NoSourceFoundTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `plainFilterProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideLines` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$git`."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/Source/Matcher/SimpleSourceLineMatcherTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideLines` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/Mago/Adapter/MagoAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideValidVersions` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/StaticAnalysis/PHPStan/Adapter/PHPStanAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideValidVersions` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Common/VersionParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidVersionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Common/VersionParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `versionProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Coverage/CoveredTraceProviderTest.php"
 code = "impossible-type-comparison"
 message = 'Impossible type assertion: `$traces` of type `array<array-key, Infection\TestFramework\Tracing\Trace\Trace>` can never be `list{int(1), int(2), int(3)}`.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `defaultCovergageDirectoryProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `defaultLocationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitReportLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `reportPathnameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -9492,150 +5382,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php"
 code = "unevaluated-code"
 message = "Unreachable code detected."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionBDDProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionCestProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/CodeceptionUnitProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/JUnitTestFileDataProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit09Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit10Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit11Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestFileDataProvider/PhpUnit12Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `defaultCovergageDirectoryProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `defaultLocationProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `reportPathnameProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `indexProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/IndexXmlCoverageParser/IndexXmlCoverageParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `noCoveredLineReportProviders` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/CodeceptionProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpSpecProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit09Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit10Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit11Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit125Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/PhpUnit12Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/SourceFileInfoProvider/SourceFileInfoProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `fileFixturesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `getTestsLocations` is imprecise, equivalent to `array<array-key, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `rangeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/TestLocatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `rangeWithoutExpectedTestsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -9657,132 +5403,6 @@ message = 'Possible argument type mismatch for argument #1 of `Infection\Tests\T
 count = 2
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/CodeceptionProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpSpecProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit09Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit10Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit11Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit120Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/PhpUnit125Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Coverage/XmlReport/XmlCoverageParser/XmlCoverageParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `lineCoverageProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/FactoryTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkAdapter` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/FactoryTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkFactory` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `coverageWithoutSourceProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `executionOrderProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `initialTestRunProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `memoryReportProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutantCommandLineProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `passOutputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `syntaxErrorOutputProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideTestCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `executionOrderProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `executionOrderValueProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `failOnProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php"
 code = "non-existent-property"
 message = "Property `$value` does not exist on class `DOMNameSpaceNode`."
@@ -9799,18 +5419,6 @@ file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderT
 code = "possibly-null-argument"
 message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::normalize` is possibly `null`, but parameter type `string` does not accept it.'
 count = 2
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `failOnProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `locationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilderTest.php"
@@ -9862,12 +5470,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `pathProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "invalid-property-access"
 message = "Attempting to access a property on a non-object type (`false`)."
 count = 1
@@ -9888,18 +5490,6 @@ count = 1
 file = "tests/phpunit/TestFramework/PhpUnit/Config/Path/PathReplacerTest.php"
 code = "possibly-null-argument"
 message = 'Argument #1 of method `Symfony\Component\Filesystem\Path::normalize` is possibly `null`, but parameter type `string` does not accept it.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidSchemaProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `schemaProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -9927,57 +5517,9 @@ message = "Parameter `$type` is never used."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `configurationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `legacyConfigurationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationVersionProviderTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mainlineConfigurationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/TestFrameworkExtraOptionsFilterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutantProcessProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/TestFrameworkTypesTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\TestFramework\DummyTestFrameworkFactory` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `locationsArrayProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
 code = "missing-parameter-type"
 message = "Parameter `$uniqueTestLocations` is missing a type hint."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "no-value"
-message = "Argument #2 passed to function `array_map` has type `never`, meaning it cannot produce a value."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestLocationBucketSorterTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\TestFramework\PhpUnit\Coverage\JUnitTimes` not found.'
 count = 1
 
 [[issues]]
@@ -10005,18 +5547,6 @@ message = "Right operand in spaceship comparison (`<=>`) might be `null` (type `
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/TestRunOrderResolverTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `scenarioProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/LineRangeCalculatorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `provideCodeAndRangeCases` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/Tracing/Trace/LineRangeCalculatorTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
@@ -10032,18 +5562,6 @@ count = 1
 file = "tests/phpunit/TestFramework/Tracing/Trace/LineRangeCalculatorTest.php"
 code = "possibly-null-argument"
 message = 'Argument #1 of method `PhpParser\NodeTraverser::traverse` is possibly `null`, but parameter type `array<array-key, PhpParser\Node>` does not accept it.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/NodeLineRangeDataTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `providesLineRanges` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/ProxyTraceTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `noTestTrace` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -10089,78 +5607,6 @@ message = "Argument #1 passed to function `iterator_to_array` has type `never`, 
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Trace/TestLocationsNormalizerTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `locationsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/CodeceptionProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpSpecProvider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit09Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit10Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit11Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit120Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/PhpUnit125Provider.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `infoProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `traceProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php"
-code = "non-existent-class"
-message = 'Class `Infection\Tests\Fixtures\TestFramework\Coverage\JUnit\FakeTestFileDataProvider` not found.'
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `invalidXmlProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `validXmlFileProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestFramework/XML/SafeDOMXPath/SafeDOMXPathTest.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
@@ -10185,48 +5631,6 @@ message = "Attempting to access a property on a possibly `null` value."
 count = 6
 
 [[issues]]
-file = "tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php"
-code = "non-existent-class-like"
-message = 'Class, Interface, or Trait `Infection\Tests\Fixtures\Mutator\CustomNameMutator` does not exist.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Testing/BaseMutatorTestCaseIntegrationTest.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `Infection\Tests\Fixtures\Mutator\CustomNameMutator` not found.'
-count = 2
-
-[[issues]]
-file = "tests/phpunit/Testing/BaseMutatorTestCaseTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `codeToWrapInMethodProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/PhpDoc/PHPDocParserTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `phpDocProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/TestFramework/Debug/DebugCommandLineTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `commandLineProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/TestFramework/Debug/DebugTestFrameworkAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `initialCommandLineProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/Testing/TestFramework/Debug/DebugTestFrameworkAdapterTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `mutantCommandLineProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/Console/Command/TestOptionCommand.php"
 code = "possibly-static-access-on-interface"
 message = 'Potential static method call on interface `Infection\Command\Option\CommandOption` via `class-string`.'
@@ -10236,12 +5640,6 @@ count = 1
 file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIteratorTest.php"
 code = "docblock-type-mismatch"
 message = '''Docblock return type `array<('TKey.infection\tests\testingutility\iterable\nonrewindableiteratortest::toarraywithoutrewind() extends mixed), ('TValue.infection\tests\testingutility\iterable\nonrewindableiteratortest::toarraywithoutrewind() extends mixed)>` is incompatible with native return type `array<array-key, mixed>`.'''
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/NonRewindableIteratorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
 count = 1
 
 [[issues]]
@@ -10258,12 +5656,6 @@ count = 1
 
 [[issues]]
 file = "tests/phpunit/TestingUtility/Iterable/TrackableIteratorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/TrackableIteratorTest.php"
 code = "less-specific-argument"
 message = 'Argument type mismatch for argument #1 of `Infection\Tests\TestingUtility\Iterable\TrackableIteratorTest::assertIteratorStateIs`: expected `Infection\Tests\TestingUtility\Iterable\TrackableIterator<array-key, mixed>`, but provided type `Infection\Tests\TestingUtility\Iterable\TrackableIterator<string, string>` is less specific.'
 count = 12
@@ -10275,45 +5667,15 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 8
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/Iterable/YieldOnceIteratorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `valuesProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/PHPUnit/DataProviderFactory.php"
 code = "mixed-operand"
 message = "Invalid right operand: template parameter `Key` is unconstrained (effectively `mixed`) and cannot be reliably used in string concatenation."
 count = 1
 
 [[issues]]
-file = "tests/phpunit/TestingUtility/PHPUnit/DataProviderFactoryTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `takeArgumentsProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
 file = "tests/phpunit/TestingUtility/PhpParser/Visitor/KeepOnlyDesiredAttributesVisitor/KeepOnlyDesiredAttributesVisitor.php"
 code = "property-type-coercion"
 message = "A value of a less specific type `array<array-key, mixed>` is being assigned to property `$desiredAttributeKeys` (array<string, mixed>)."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PhpParser/Visitor/KeepOnlyDesiredAttributesVisitor/KeepOnlyDesiredAttributesVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `attributeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/TestingUtility/PhpParser/Visitor/SkipNodesVisitor/SkipNodesVisitorTest.php"
-code = "imprecise-type"
-message = "Type `iterable` in return type of `nodeProvider` is imprecise, equivalent to `iterable<mixed, mixed>`."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/WithConsecutive.php"
-code = "imprecise-type"
-message = "Type `array` in return type of `create` is imprecise, equivalent to `array<array-key, mixed>`."
 count = 1
 
 [[issues]]

--- a/src/Mutator/Arithmetic/DivEqual.php
+++ b/src/Mutator/Arithmetic/DivEqual.php
@@ -91,7 +91,7 @@ final class DivEqual implements Mutator
 
     private function isNumericOne(Node $node): bool
     {
-        if ($node instanceof Node\Scalar\LNumber && $node->value === 1) {
+        if ($node instanceof Node\Scalar\Int_ && $node->value === 1) {
             return true;
         }
 

--- a/src/Mutator/Arithmetic/Division.php
+++ b/src/Mutator/Arithmetic/Division.php
@@ -93,7 +93,7 @@ final class Division implements Mutator
 
     private function isNumericOne(Node $node): bool
     {
-        if ($node instanceof Node\Scalar\LNumber && $node->value === 1) {
+        if ($node instanceof Node\Scalar\Int_ && $node->value === 1) {
             return true;
         }
 

--- a/src/Mutator/Arithmetic/MulEqual.php
+++ b/src/Mutator/Arithmetic/MulEqual.php
@@ -91,7 +91,7 @@ final class MulEqual implements Mutator
 
     private function isNumericOne(Node $node): bool
     {
-        if ($node instanceof Node\Scalar\LNumber && $node->value === 1) {
+        if ($node instanceof Node\Scalar\Int_ && $node->value === 1) {
             return true;
         }
 

--- a/src/Mutator/Arithmetic/Multiplication.php
+++ b/src/Mutator/Arithmetic/Multiplication.php
@@ -120,7 +120,7 @@ final class Multiplication implements Mutator
 
     private function isNumericOne(Node $node): bool
     {
-        if ($node instanceof Node\Scalar\LNumber && $node->value === 1) {
+        if ($node instanceof Node\Scalar\Int_ && $node->value === 1) {
             return true;
         }
 

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -153,7 +153,7 @@ final class LogicalOr implements Mutator
             if ($nodeLeftLeft instanceof Node\Expr\Variable) {
                 $varNameLeft = $nodeLeftLeft->name;
             } elseif (
-                $nodeLeftLeft instanceof Node\Scalar\LNumber
+                $nodeLeftLeft instanceof Node\Scalar\Int_
                 || $nodeLeftLeft instanceof Node\Scalar\DNumber
             ) {
                 $valueLeft = $nodeLeftLeft->value;
@@ -165,7 +165,7 @@ final class LogicalOr implements Mutator
                 $varNameLeft = $nodeLeftRight->name;
             } elseif (
                 (
-                    $nodeLeftRight instanceof Node\Scalar\LNumber
+                    $nodeLeftRight instanceof Node\Scalar\Int_
                     || $nodeLeftRight instanceof Node\Scalar\DNumber
                 ) && $valueLeft === null
             ) {
@@ -180,7 +180,7 @@ final class LogicalOr implements Mutator
             if ($nodeRightLeft instanceof Node\Expr\Variable) {
                 $varNameRight = $nodeRightLeft->name;
             } elseif (
-                $nodeRightLeft instanceof Node\Scalar\LNumber
+                $nodeRightLeft instanceof Node\Scalar\Int_
                 || $nodeRightLeft instanceof Node\Scalar\DNumber
             ) {
                 $valueRight = $nodeRightLeft->value;
@@ -192,7 +192,7 @@ final class LogicalOr implements Mutator
                 $varNameRight = $nodeRightRight->name;
             } elseif (
                 (
-                    $nodeRightRight instanceof Node\Scalar\LNumber
+                    $nodeRightRight instanceof Node\Scalar\Int_
                     || $nodeRightRight instanceof Node\Scalar\DNumber
                 ) && $valueRight === null
             ) {

--- a/src/Mutator/Extensions/MBString.php
+++ b/src/Mutator/Extensions/MBString.php
@@ -207,7 +207,7 @@ final readonly class MBString implements ConfigurableMutator
 
         $mode = $node->args[1]->value;
 
-        if ($mode instanceof Node\Scalar\LNumber) {
+        if ($mode instanceof Node\Scalar\Int_) {
             return $mode->value;
         }
 

--- a/src/Mutator/Number/DecrementInteger.php
+++ b/src/Mutator/Number/DecrementInteger.php
@@ -48,7 +48,7 @@ use function stripos;
 /**
  * @internal
  *
- * @extends AbstractNumberMutator<Node\Scalar\LNumber>
+ * @extends AbstractNumberMutator<Node\Scalar\Int_>
  */
 final class DecrementInteger extends AbstractNumberMutator
 {
@@ -88,7 +88,7 @@ final class DecrementInteger extends AbstractNumberMutator
     /**
      * @psalm-mutation-free
      *
-     * @return iterable<Node\Scalar\LNumber>
+     * @return iterable<Node\Scalar\Int_>
      */
     public function mutate(Node $node): iterable
     {
@@ -108,12 +108,12 @@ final class DecrementInteger extends AbstractNumberMutator
             $value = $node->value + 1;
         }
 
-        yield new Node\Scalar\LNumber($value);
+        yield new Node\Scalar\Int_($value);
     }
 
     public function canMutate(Node $node): bool
     {
-        if (!$node instanceof Node\Scalar\LNumber) {
+        if (!$node instanceof Node\Scalar\Int_) {
             return false;
         }
 
@@ -150,7 +150,7 @@ final class DecrementInteger extends AbstractNumberMutator
         return $this->isAllowedComparison($node);
     }
 
-    private function isAllowedComparison(Node\Scalar\LNumber $node): bool
+    private function isAllowedComparison(Node\Scalar\Int_ $node): bool
     {
         if ($node->value !== 0) {
             return true;
@@ -220,7 +220,7 @@ final class DecrementInteger extends AbstractNumberMutator
         return false;
     }
 
-    private function isArrayZeroIndexAccess(Node\Scalar\LNumber $node): bool
+    private function isArrayZeroIndexAccess(Node\Scalar\Int_ $node): bool
     {
         if ($node->value !== 0) {
             return false;
@@ -229,7 +229,7 @@ final class DecrementInteger extends AbstractNumberMutator
         return ParentConnector::getParent($node) instanceof Node\Expr\ArrayDimFetch;
     }
 
-    private function isPregSplitLimitZeroOrMinusOneArgument(Node\Scalar\LNumber $node): bool
+    private function isPregSplitLimitZeroOrMinusOneArgument(Node\Scalar\Int_ $node): bool
     {
         if ($node->value !== 0) {
             return false;

--- a/src/Mutator/Number/IncrementInteger.php
+++ b/src/Mutator/Number/IncrementInteger.php
@@ -46,7 +46,7 @@ use PhpParser\Node;
 /**
  * @internal
  *
- * @extends AbstractNumberMutator<Node\Scalar\LNumber>
+ * @extends AbstractNumberMutator<Node\Scalar\Int_>
  */
 final class IncrementInteger extends AbstractNumberMutator
 {
@@ -72,7 +72,7 @@ final class IncrementInteger extends AbstractNumberMutator
     /**
      * @psalm-mutation-free
      *
-     * @return iterable<Node\Scalar\LNumber>
+     * @return iterable<Node\Scalar\Int_>
      */
     public function mutate(Node $node): iterable
     {
@@ -89,12 +89,12 @@ final class IncrementInteger extends AbstractNumberMutator
             $value = $node->value - 1;
         }
 
-        yield new Node\Scalar\LNumber($value);
+        yield new Node\Scalar\Int_($value);
     }
 
     public function canMutate(Node $node): bool
     {
-        if (!$node instanceof Node\Scalar\LNumber) {
+        if (!$node instanceof Node\Scalar\Int_) {
             return false;
         }
 
@@ -123,7 +123,7 @@ final class IncrementInteger extends AbstractNumberMutator
         return $this->isAllowedComparison($node);
     }
 
-    private function isPregSplitLimitZeroOrMinusOneArgument(Node\Scalar\LNumber $node): bool
+    private function isPregSplitLimitZeroOrMinusOneArgument(Node\Scalar\Int_ $node): bool
     {
         if ($node->value !== 1) {
             return false;
@@ -149,7 +149,7 @@ final class IncrementInteger extends AbstractNumberMutator
         ;
     }
 
-    private function isAllowedComparison(Node\Scalar\LNumber $node): bool
+    private function isAllowedComparison(Node\Scalar\Int_ $node): bool
     {
         if (!$this->isPartOfComparison($node)) {
             return true;

--- a/src/Mutator/Operator/SpreadOneItem.php
+++ b/src/Mutator/Operator/SpreadOneItem.php
@@ -89,7 +89,7 @@ final class SpreadOneItem implements Mutator
                     [$node],
                     NodeAttributes::getAllExceptOriginalNode($node) + ['kind' => Node\Expr\Array_::KIND_SHORT],
                 ),
-                new Node\Scalar\LNumber(0),
+                new Node\Scalar\Int_(0),
                 NodeAttributes::getAllExceptOriginalNode($node->value),
             ),
             null,

--- a/src/Mutator/ReturnValue/ArrayOneItem.php
+++ b/src/Mutator/ReturnValue/ArrayOneItem.php
@@ -97,12 +97,12 @@ final class ArrayOneItem implements Mutator
             new Node\Expr\Ternary(
                 new Node\Expr\BinaryOp\Greater(
                     new Node\Expr\FuncCall(new Node\Name('count'), [new Node\Arg($arrayVariable)]),
-                    new Node\Scalar\LNumber(1),
+                    new Node\Scalar\Int_(1),
                 ),
                 new Node\Expr\FuncCall(new Node\Name('array_slice'), [
                     new Node\Arg($arrayVariable),
-                    new Node\Arg(new Node\Scalar\LNumber(0)),
-                    new Node\Arg(new Node\Scalar\LNumber(1)),
+                    new Node\Arg(new Node\Scalar\Int_(0)),
+                    new Node\Arg(new Node\Scalar\Int_(1)),
                     new Node\Arg(new Node\Expr\ConstFetch(new Node\Name('true'))),
                 ]),
                 $arrayVariable,

--- a/src/Mutator/ReturnValue/FloatNegation.php
+++ b/src/Mutator/ReturnValue/FloatNegation.php
@@ -108,7 +108,7 @@ final class FloatNegation implements Mutator
         $expression = $node->expr;
 
         if ($expression instanceof Node\Expr\UnaryMinus) {
-            /** @var Node\Scalar\LNumber $innerExpression */
+            /** @var Node\Scalar\DNumber $innerExpression */
             $innerExpression = $expression->expr;
 
             return -$innerExpression->value;

--- a/src/Mutator/ReturnValue/IntegerNegation.php
+++ b/src/Mutator/ReturnValue/IntegerNegation.php
@@ -74,7 +74,7 @@ final class IntegerNegation implements Mutator
     public function mutate(Node $node): iterable
     {
         yield new Node\Stmt\Return_(
-            new Node\Scalar\LNumber(-1 * $this->getIntegerValueOfNode($node), NodeAttributes::getAllExceptOriginalNode($node)),
+            new Node\Scalar\Int_(-1 * $this->getIntegerValueOfNode($node), NodeAttributes::getAllExceptOriginalNode($node)),
         );
     }
 
@@ -90,7 +90,7 @@ final class IntegerNegation implements Mutator
             $expr = $expr->expr;
         }
 
-        if (!$expr instanceof Node\Scalar\LNumber) {
+        if (!$expr instanceof Node\Scalar\Int_) {
             return false;
         }
 
@@ -104,11 +104,11 @@ final class IntegerNegation implements Mutator
      */
     private function getIntegerValueOfNode(Node $node): int
     {
-        /** @var Node\Expr\UnaryMinus|Node\Scalar\LNumber $expression */
+        /** @var Node\Expr\UnaryMinus|Node\Scalar\Int_ $expression */
         $expression = $node->expr;
 
         if ($expression instanceof Node\Expr\UnaryMinus) {
-            /** @var Node\Scalar\LNumber $innerExpression */
+            /** @var Node\Scalar\Int_ $innerExpression */
             $innerExpression = $expression->expr;
 
             return -$innerExpression->value;

--- a/src/Mutator/Sort/Spaceship.php
+++ b/src/Mutator/Sort/Spaceship.php
@@ -107,11 +107,11 @@ final class Spaceship implements Mutator
             return false;
         }
 
-        if ($node->right instanceof Node\Scalar\LNumber && $node->right->value === 0) {
+        if ($node->right instanceof Node\Scalar\Int_ && $node->right->value === 0) {
             return true;
         }
 
-        return $node->left instanceof Node\Scalar\LNumber
+        return $node->left instanceof Node\Scalar\Int_
             && $node->left->value === 0;
     }
 

--- a/tests/phpunit/Mutation/MutationTest.php
+++ b/tests/phpunit/Mutation/MutationTest.php
@@ -124,8 +124,8 @@ final class MutationTest extends TestCase
             'mutatorClass' => Plus::class,
             'mutatorName' => MutatorName::getName(Plus::class),
             'attributes' => $nominalAttributes,
-            'mutatedNodeClass' => Node\Scalar\LNumber::class,
-            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\LNumber(1)),
+            'mutatedNodeClass' => Node\Scalar\Int_::class,
+            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\Int_(1)),
             'mutationByMutatorIndex' => -1,
             'tests' => [],
             'originalFileTokens' => [],
@@ -141,13 +141,13 @@ final class MutationTest extends TestCase
             'originalFilePath' => '/path/to/acme/Foo.php',
             'originalFileAst' => [new Node\Stmt\Namespace_(
                 new Node\Name('Acme'),
-                [new Node\Scalar\LNumber(0)],
+                [new Node\Scalar\Int_(0)],
             )],
             'mutatorClass' => Plus::class,
             'mutatorName' => MutatorName::getName(Plus::class),
             'attributes' => $nominalAttributes,
-            'mutatedNodeClass' => Node\Scalar\LNumber::class,
-            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\LNumber(1)),
+            'mutatedNodeClass' => Node\Scalar\Int_::class,
+            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\Int_(1)),
             'mutationByMutatorIndex' => 0,
             'tests' => [
                 new TestLocation(
@@ -169,13 +169,13 @@ final class MutationTest extends TestCase
             'originalFilePath' => '/path/to/acme/Foo.php',
             'originalFileAst' => [new Node\Stmt\Namespace_(
                 new Node\Name('Acme'),
-                [new Node\Scalar\LNumber(0)],
+                [new Node\Scalar\Int_(0)],
             )],
             'mutatorClass' => Plus::class,
             'mutatorName' => MutatorName::getName(Plus::class),
             'attributes' => $nominalAttributes,
-            'mutatedNodeClass' => Node\Scalar\LNumber::class,
-            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\LNumber(1)),
+            'mutatedNodeClass' => Node\Scalar\Int_::class,
+            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\Int_(1)),
             'mutationByMutatorIndex' => 99,
             'tests' => [
                 new TestLocation(
@@ -197,13 +197,13 @@ final class MutationTest extends TestCase
             'originalFilePath' => '/path/to/acme/Foo.php',
             'originalFileAst' => [new Node\Stmt\Namespace_(
                 new Node\Name('Acme'),
-                [new Node\Scalar\LNumber(0)],
+                [new Node\Scalar\Int_(0)],
             )],
             'mutatorClass' => Plus::class,
             'mutatorName' => MutatorName::getName(Plus::class),
             'attributes' => array_merge($nominalAttributes, ['foo' => 100, 'bar' => 1000]),
-            'mutatedNodeClass' => Node\Scalar\LNumber::class,
-            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\LNumber(1)),
+            'mutatedNodeClass' => Node\Scalar\Int_::class,
+            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\Int_(1)),
             'mutationByMutatorIndex' => 0,
             'tests' => [
                 new TestLocation(
@@ -230,13 +230,13 @@ final class MutationTest extends TestCase
             'originalFilePath' => '/path/to/acme/Foo.php',
             'originalFileAst' => [new Node\Stmt\Namespace_(
                 new Node\Name('Acme'),
-                [new Node\Scalar\LNumber(0)],
+                [new Node\Scalar\Int_(0)],
             )],
             'mutatorClass' => Plus::class,
             'mutatorName' => MutatorName::getName(Plus::class),
             'attributes' => $nominalAttributes,
-            'mutatedNodeClass' => Node\Scalar\LNumber::class,
-            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\LNumber(1)),
+            'mutatedNodeClass' => Node\Scalar\Int_::class,
+            'mutatedNode' => MutatedNode::wrap(new Node\Scalar\Int_(1)),
             'mutationByMutatorIndex' => 0,
             'tests' => [],
             'originalFileTokens' => [],
@@ -252,15 +252,15 @@ final class MutationTest extends TestCase
             'originalFilePath' => '/path/to/acme/Foo.php',
             'originalFileAst' => [new Node\Stmt\Namespace_(
                 new Node\Name('Acme'),
-                [new Node\Scalar\LNumber(0)],
+                [new Node\Scalar\Int_(0)],
             )],
             'mutatorClass' => Plus::class,
             'mutatorName' => MutatorName::getName(Plus::class),
             'attributes' => $nominalAttributes,
-            'mutatedNodeClass' => Node\Scalar\LNumber::class,
+            'mutatedNodeClass' => Node\Scalar\Int_::class,
             'mutatedNode' => MutatedNode::wrap([
-                new Node\Scalar\LNumber(1),
-                new Node\Scalar\LNumber(-1),
+                new Node\Scalar\Int_(1),
+                new Node\Scalar\Int_(-1),
             ]),
             'mutationByMutatorIndex' => 0,
             'tests' => [

--- a/tests/phpunit/Mutator/Arithmetic/PlusTest.php
+++ b/tests/phpunit/Mutator/Arithmetic/PlusTest.php
@@ -39,7 +39,7 @@ use Infection\Mutator\Arithmetic\Plus;
 use Infection\Testing\BaseMutatorTestCase;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -116,7 +116,7 @@ final class PlusTest extends BaseMutatorTestCase
 
     public function test_it_should_mutate_plus_expression(): void
     {
-        $plusExpression = new Node\Expr\BinaryOp\Plus(new LNumber(1), new LNumber(2));
+        $plusExpression = new Node\Expr\BinaryOp\Plus(new Int_(1), new Int_(2));
 
         $this->assertTrue($this->mutator->canMutate($plusExpression));
     }
@@ -124,8 +124,8 @@ final class PlusTest extends BaseMutatorTestCase
     public function test_it_should_not_mutate_plus_with_arrays(): void
     {
         $plusExpression = new Node\Expr\BinaryOp\Plus(
-            new Array_([new LNumber(1)]),
-            new Array_([new LNumber(1)]),
+            new Array_([new Int_(1)]),
+            new Array_([new Int_(1)]),
         );
 
         $this->assertFalse($this->mutator->canMutate($plusExpression));

--- a/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
+++ b/tests/phpunit/Mutator/ReturnValue/IntegerNegationTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\Mutator\ReturnValue;
 
 use Infection\Mutator\ReturnValue\IntegerNegation;
 use Infection\Testing\BaseMutatorTestCase;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt\Return_;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -127,7 +127,7 @@ final class IntegerNegationTest extends BaseMutatorTestCase
 
     public function test_it_does_not_mutate_zero(): void
     {
-        $node = new Return_(new LNumber(0));
+        $node = new Return_(new Int_(0));
         $this->assertFalse($this->createMutator()->canMutate($node));
     }
 }

--- a/tests/phpunit/PhpParser/MutatedNodeTest.php
+++ b/tests/phpunit/PhpParser/MutatedNodeTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\PhpParser;
 
 use Infection\PhpParser\MutatedNode;
 use PhpParser\Node;
-use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\Int_;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -49,7 +49,7 @@ final class MutatedNodeTest extends TestCase
      * @param Node|Node[] $node
      */
     #[DataProvider('nodeProvider')]
-    public function test_it_can_be_instantiated(LNumber|array $node): void
+    public function test_it_can_be_instantiated(Int_|array $node): void
     {
         $mutatedNode = MutatedNode::wrap($node);
 
@@ -58,12 +58,12 @@ final class MutatedNodeTest extends TestCase
 
     public static function nodeProvider(): iterable
     {
-        yield 'single node' => [new LNumber(1)];
+        yield 'single node' => [new Int_(1)];
 
         yield 'multiple nodes' => [
             [
-                new LNumber(1),
-                new LNumber(-1),
+                new Int_(1),
+                new Int_(-1),
             ],
         ];
     }


### PR DESCRIPTION
## Description

php-parser deprecated `LNumber/DNumber` in favor of `Int_`/`Float_`; let's update mutators and tests to the new class names and shrink the Mago baseline.

We have nikic/php-parser at `^5.6.2`, and `Int_` was introduced in 5.0.0.

### Reviewer Notes

This is mostly a search and replace kind of thing, with a singular exception - I commented inline.

Escaping mutants are fixed by #3463
