### PR TITLE
fix(phpunit): Prevent Windows environment block overflow

### DIFF
--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -41,6 +41,7 @@ use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
 use Infection\Configuration\Configuration;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
+use Infection\Framework\OperatingSystem;
 use Infection\Source\Collector\SourceCollector;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\Contracts\ShellCommandLineExecutor;
@@ -107,6 +108,7 @@ final readonly class Factory
                 $this->infectionConfig->mapSourceClassToTestStrategy,
                 $this->shellCommandLineExecutor,
                 sourceDirectoryBasePath: dirname($this->infectionConfig->configurationPathname),
+                useWindowsFilterLimit: OperatingSystem::isWindows(),
             );
         }
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -83,6 +83,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
         ?string $mapSourceClassToTestStrategy = null,
         ?ShellCommandLineExecutor $shellCommandLineExecutor = null,
         ?string $sourceDirectoryBasePath = null,
+        bool $useWindowsFilterLimit = false,
     ): TestFrameworkAdapter {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the adapter');
         Assert::notEmpty(
@@ -142,6 +143,7 @@ final class PhpUnitAdapterFactory implements TestFrameworkAdapterFactory
                 $executeOnlyCoveringTestCases,
                 $filteredSourceFilesToMutate,
                 $mapSourceClassToTestStrategy,
+                $useWindowsFilterLimit,
             ),
             $shellCommandLineExecutor,
             new VersionParser(),

--- a/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilder.php
@@ -57,6 +57,7 @@ final readonly class ArgumentsAndOptionsBuilder implements CommandLineArgumentsA
         private bool $executeOnlyCoveringTestCases,
         private array $filteredSourceFilesToMutate,
         private ?string $mapSourceClassToTestStrategy,
+        private bool $useWindowsFilterLimit,
     ) {
     }
 
@@ -142,7 +143,11 @@ final readonly class ArgumentsAndOptionsBuilder implements CommandLineArgumentsA
         array $tests,
         string $testFrameworkVersion,
     ): ?string {
-        $filters = FilterBuilder::createFilters($tests, $testFrameworkVersion);
+        $filters = FilterBuilder::createFilters(
+            $tests,
+            $testFrameworkVersion,
+            useWindowsFilterLimit: $this->useWindowsFilterLimit,
+        );
 
         return count($filters) === 0
             ? null

--- a/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
@@ -59,6 +59,14 @@ final class FilterBuilder
     // The real limit is likely higher, but it is better to be safe than sorry.
     private const int PCRE_LIMIT = 30_000;
 
+    /*
+     * Symfony may transport command arguments through the environment on Windows, where the
+     * complete environment block is limited to 32,767 UTF-16 code units. This conservative
+     * limit reserves headroom for inherited variables, may intentionally degrade filters
+     * earlier, and is not an exact guarantee.
+     */
+    private const int WINDOWS_FILTER_LIMIT = 10_000;
+
     private const int NO_OPTIMIZATION_LEVEL = 0;
 
     private const int DROP_DATA_PROVIDER_KEY_OPTIMIZATION_LEVEL = 1;
@@ -69,17 +77,22 @@ final class FilterBuilder
 
     /**
      * @param non-empty-array<TestLocation> $tests
+     * @param self::NO_OPTIMIZATION_LEVEL|self::DROP_DATA_PROVIDER_KEY_OPTIMIZATION_LEVEL|self::DROP_TEST_CASE_OPTIMIZATION_LEVEL|self::BAILOUT_OPTIMIZATION_LEVEL $optimizationLevel
      *
      * @return list<string>
      */
     public static function createFilters(
         array $tests,
         string $testFrameworkVersion,
+        bool $useWindowsFilterLimit,
         int $optimizationLevel = self::NO_OPTIMIZATION_LEVEL,
     ): array {
         $usedTests = [];
         $filters = [];
         $totalFilterLength = 0;
+        $maxFilterLength = $useWindowsFilterLimit
+            ? self::WINDOWS_FILTER_LIMIT
+            : self::PCRE_LIMIT;
 
         if ($optimizationLevel === self::BAILOUT_OPTIMIZATION_LEVEL) {
             // We have no further optimisation strategy at this point, so we
@@ -114,12 +127,14 @@ final class FilterBuilder
             $usedTests[$test] = true;
 
             $filter = preg_quote($test, '/');
+
             $totalFilterLength += strlen($filter);
 
-            if ($totalFilterLength > self::PCRE_LIMIT) {
+            if ($totalFilterLength > $maxFilterLength) {
                 return self::createFilters(
                     $tests,
                     $testFrameworkVersion,
+                    $useWindowsFilterLimit,
                     $optimizationLevel + 1,
                 );
             }

--- a/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
+++ b/src/TestFramework/PhpUnit/CommandLine/FilterBuilder.php
@@ -84,7 +84,7 @@ final class FilterBuilder
     public static function createFilters(
         array $tests,
         string $testFrameworkVersion,
-        bool $useWindowsFilterLimit,
+        bool $useWindowsFilterLimit = false,
         int $optimizationLevel = self::NO_OPTIMIZATION_LEVEL,
     ): array {
         $usedTests = [];

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapter/PhpUnitAdapterTest.php
@@ -1667,6 +1667,7 @@ final class PhpUnitAdapterTest extends TestCase
                 $executeOnlyCoveringTestCases,
                 $filteredSourceFilesToMutate,
                 $mapSourceClassToTestStrategy,
+                false,
             ),
             $shellCommandLineExecutor ?? $this->createStub(ShellCommandLineExecutor::class),
             new VersionParser(),    // won't be used since we pass the version

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -193,6 +193,23 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
         $this->assertSame($expectedArgumentsAndOptions, $actual);
     }
 
+    public function test_it_can_build_the_filter_string_with_the_default_non_windows_limit(): void
+    {
+        $providerKey = str_repeat('x', 9_960);
+
+        $this->assertSame(
+            [
+                'ServiceTest\:\:test_case with data set "' . $providerKey . '"',
+            ],
+            FilterBuilder::createFilters(
+                [
+                    TestLocation::forTestMethod('App\ServiceTest::test_case#' . $providerKey),
+                ],
+                '10.1',
+            ),
+        );
+    }
+
     public static function provideTestCases(): iterable
     {
         $phpunit9 = '9.5';

--- a/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/CommandLine/ArgumentsAndOptionsBuilderTest.php
@@ -48,6 +48,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 use function sprintf;
+use function str_repeat;
 
 #[CoversClass(ArgumentsAndOptionsBuilder::class)]
 #[CoversClass(FilterBuilder::class)]
@@ -56,7 +57,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
 {
     public function test_it_can_build_the_command_without_extra_options(): void
     {
-        $builder = new ArgumentsAndOptionsBuilder(false, [], null);
+        $builder = new ArgumentsAndOptionsBuilder(false, [], null, false);
         $configPath = '/config/path';
 
         $this->assertSame(
@@ -70,7 +71,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
 
     public function test_it_can_build_the_command_with_extra_options(): void
     {
-        $builder = new ArgumentsAndOptionsBuilder(false, [], null);
+        $builder = new ArgumentsAndOptionsBuilder(false, [], null, false);
         $configPath = '/config/path';
 
         $this->assertSame(
@@ -86,7 +87,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
 
     public function test_it_can_build_the_command_with_raw_extra_args(): void
     {
-        $builder = new ArgumentsAndOptionsBuilder(false, [], null);
+        $builder = new ArgumentsAndOptionsBuilder(false, [], null, false);
         $configPath = '/config/path';
 
         $this->assertSame(
@@ -112,6 +113,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
                 new SplFileInfo('src/bar/Baz.php'),
             ],
             'simple',
+            false,
         );
         $configPath = '/config/path';
 
@@ -130,7 +132,7 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
 
     public function test_it_can_build_the_command_with_extra_options_that_contains_spaces(): void
     {
-        $builder = new ArgumentsAndOptionsBuilder(false, [], null);
+        $builder = new ArgumentsAndOptionsBuilder(false, [], null, false);
         $configPath = '/the config/path';
 
         $this->assertSame(
@@ -154,10 +156,16 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
         array $testCases,
         string $phpUnitVersion,
         ?string $expectedFilterOptionValue,
+        bool $useWindowsFilterLimit = false,
     ): void {
         $configPath = '/the config/path';
 
-        $builder = new ArgumentsAndOptionsBuilder($executeOnlyCoveringTestCases, [], null);
+        $builder = new ArgumentsAndOptionsBuilder(
+            $executeOnlyCoveringTestCases,
+            [],
+            null,
+            $useWindowsFilterLimit,
+        );
 
         $expectedArgumentsAndOptions = [
             '--configuration',
@@ -350,6 +358,50 @@ final class ArgumentsAndOptionsBuilderTest extends TestCase
             ],
             $phpunit10,
             '/ServiceTest\:\:test_case1 with data set "With special character \\>@&\\\\\\:\\:"|ServiceTest\:\:test_case2/',
+        ];
+
+        yield 'Windows limit accepts the exact 10,000-byte fragment boundary' => [
+            'executeOnlyCoveringTestCases' => true,
+            'testCases' => [
+                'App\ServiceTest::test_case#' . str_repeat('x', 9_959),
+            ],
+            'phpUnitVersion' => $phpunit10,
+            'expectedFilterOptionValue' => '/ServiceTest\:\:test_case with data set "' . str_repeat('x', 9_959) . '"/',
+            'useWindowsFilterLimit' => true,
+        ];
+
+        yield 'Windows limit drops the provider key for a 10,001-byte fragment' => [
+            'executeOnlyCoveringTestCases' => true,
+            'testCases' => [
+                'App\ServiceTest::test_case#' . str_repeat('x', 9_960),
+            ],
+            'phpUnitVersion' => $phpunit10,
+            'expectedFilterOptionValue' => '/ServiceTest\:\:test_case/',
+            'useWindowsFilterLimit' => true,
+        ];
+
+        yield 'PCRE limit accepts the same 10,001-byte fragment' => [
+            'executeOnlyCoveringTestCases' => true,
+            'testCases' => [
+                'App\ServiceTest::test_case#' . str_repeat('x', 9_960),
+            ],
+            'phpUnitVersion' => $phpunit10,
+            'expectedFilterOptionValue' => '/ServiceTest\:\:test_case with data set "' . str_repeat('x', 9_960) . '"/',
+        ];
+
+        yield '240 provider keys totaling 29,760 fragment bytes degrade to the method level on Windows' => [
+            'executeOnlyCoveringTestCases' => true,
+            'testCases' => self::createArray(
+                static fn (int $index) => sprintf(
+                    'App\ServiceTest::test_case#dataset_%03d_%s',
+                    $index,
+                    str_repeat('x', 71),
+                ),
+                240,
+            ),
+            'phpUnitVersion' => $phpunit10,
+            'expectedFilterOptionValue' => '/ServiceTest\:\:test_case/',
+            'useWindowsFilterLimit' => true,
         ];
 
         yield 'too many tests; all from the same test case' => [


### PR DESCRIPTION
## Description

On Windows, `--only-covering-test-cases` can generate a quoted PHPUnit `--filter` that remains below Infection's 30,000-byte PCRE guard but makes Symfony Process exceed the 32,767 UTF-16-code-unit environment-block limit. The mutant process then cannot start and the mutation campaign aborts.

This PR applies a conservative 10,000-byte filter-fragment limit on Windows. When the limit is exceeded, Infection reuses its existing filter optimization ladder to progressively broaden the test selection instead of aborting the mutation campaign.

The available environment capacity depends on the inherited variables, so the 10,000-byte limit deliberately leaves additional headroom and is a heuristic rather than an exact guarantee. Non-Windows platforms retain the existing 30,000-byte PCRE limit.

## Changes

- Detect Windows before constructing the PHPUnit adapter and pass that information to the filter builder.
- Apply a 10,000-byte cumulative filter-fragment limit on Windows.
- Retain the existing 30,000-byte PCRE limit on non-Windows platforms.
- Reuse the existing filter optimization ladder when either limit is exceeded.
- Add regression coverage for both limit boundaries and the original 240-provider-key scenario.

## Reviewer Notes

The Windows limit is intentionally conservative. Calculating the exact available capacity would depend on the inherited environment and Symfony Process's command preparation for each child process.

The operating-system check intentionally lives in `Infection\TestFramework\Factory`, which acts as the composition boundary. PHPat restricts new dependencies from the PHPUnit adapter package to Infection's core namespaces. Detecting Windows there and passing a boolean avoids introducing another package-boundary violation.

## Related issues

Fixes https://github.com/infection/infection/issues/3435.
