### PR TITLE
build: Allow sanmai/di-container ^0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "nikic/php-parser": "^5.6.2",
         "ondram/ci-detector": "^4.1.0",
         "psr/log": "^2.0 || ^3.0",
-        "sanmai/di-container": "^0.1.22",
+        "sanmai/di-container": "^0.1.23 || ^0.2",
         "sanmai/duoclock": "^0.1.0",
         "sanmai/later": "^0.1.7",
         "sanmai/pipeline": "^7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80c50f030ea0a59e9464784b4a440567",
+    "content-hash": "8ceb0af830a2d628a439bac569d36ed3",
     "packages": [
         {
             "name": "colinodell/json5",


### PR DESCRIPTION

## Description

Widens the version constraint so the project can pick up 0.2.x releases of the DI container.

I fixed a [bug with cloning](https://github.com/sanmai/di-container/issues/98), and I had to make a new major version because I had to add `__clone()` which breaks any container that had private `__clone()` typically used to prevent clones.



