### PR TITLE
fix(mutator): Guard LogicalOr against non-string variable variable names

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -337,18 +337,6 @@ parameters:
 			path: ../src/Mutant/MutantExecutionResult.php
 
 		-
-			rawMessage: 'Parameter #1 $array of function array_intersect expects an array of values castable to string, list<PhpParser\Node\Expr|string> given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Mutator/Boolean/LogicalOr.php
-
-		-
-			rawMessage: 'Parameter #2 $arrays of function array_intersect expects an array of values castable to string, list<PhpParser\Node\Expr|string> given.'
-			identifier: argument.type
-			count: 1
-			path: ../src/Mutator/Boolean/LogicalOr.php
-
-		-
 			rawMessage: Do not use magic number as a function argument. Move to constant with a suitable name.
 			count: 8
 			path: ../src/Mutator/Extensions/BCMath.php

--- a/src/Mutator/Boolean/LogicalOr.php
+++ b/src/Mutator/Boolean/LogicalOr.php
@@ -120,21 +120,21 @@ final class LogicalOr implements Mutator
         if ($leftSigil === '===' && $rightSigil === '===') {
             $varNameLeft = [];
 
-            if ($nodeLeftLeft instanceof Node\Expr\Variable) {
+            if ($nodeLeftLeft instanceof Node\Expr\Variable && is_string($nodeLeftLeft->name)) {
                 $varNameLeft[] = $nodeLeftLeft->name;
             }
 
-            if ($nodeLeftRight instanceof Node\Expr\Variable) {
+            if ($nodeLeftRight instanceof Node\Expr\Variable && is_string($nodeLeftRight->name)) {
                 $varNameLeft[] = $nodeLeftRight->name;
             }
 
             $varNameRight = [];
 
-            if ($nodeRightLeft instanceof Node\Expr\Variable) {
+            if ($nodeRightLeft instanceof Node\Expr\Variable && is_string($nodeRightLeft->name)) {
                 $varNameRight[] = $nodeRightLeft->name;
             }
 
-            if ($nodeRightRight instanceof Node\Expr\Variable) {
+            if ($nodeRightRight instanceof Node\Expr\Variable && is_string($nodeRightRight->name)) {
                 $varNameRight[] = $nodeRightRight->name;
             }
 

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -213,6 +213,21 @@ final class LogicalOrTest extends BaseMutatorTestCase
                     PHP,
             ),
         ];
+
+        yield 'It mutates logical or when the same variable variable is tested against "Identical" on both sides' => [
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    ${$s} === 'hello' || ${$s} === 'world';
+                    PHP,
+            ),
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    ${$s} === 'hello' && ${$s} === 'world';
+                    PHP,
+            ),
+        ];
     }
 
     private static function nonMutableSmallerAndGreaterMatrixMutationsProvider(): iterable

--- a/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
+++ b/tests/phpunit/Mutator/Boolean/LogicalOrTest.php
@@ -153,6 +153,66 @@ final class LogicalOrTest extends BaseMutatorTestCase
                     PHP,
             ),
         ];
+
+        yield 'It mutates logical or when used with a variable variable' => [
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    ${$s} === 'hello' || $myVar === 'world';
+                    PHP,
+            ),
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    ${$s} === 'hello' && $myVar === 'world';
+                    PHP,
+            ),
+        ];
+
+        yield 'It mutates logical or when used with a variable variable (inverse)' => [
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    $myVar === 'hello' || ${$s} === 'world';
+                    PHP,
+            ),
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    $myVar === 'hello' && ${$s} === 'world';
+                    PHP,
+            ),
+        ];
+
+        yield 'It mutates logical or when a variable variable is the right operand' => [
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    'hello' === ${$s} || $myVar === 'world';
+                    PHP,
+            ),
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    'hello' === ${$s} && $myVar === 'world';
+                    PHP,
+            ),
+        ];
+
+        yield 'It mutates logical or when a variable variable is the right operand (inverse)' => [
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    $myVar === 'hello' || 'world' === ${$s};
+                    PHP,
+            ),
+            self::wrapCodeInMethod(
+                <<<'PHP'
+                    $s = 'other';
+                    $myVar === 'hello' && 'world' === ${$s};
+                    PHP,
+            ),
+        ];
     }
 
     private static function nonMutableSmallerAndGreaterMatrixMutationsProvider(): iterable


### PR DESCRIPTION

## Description

`${$s}` has a dynamic (Expr) name rather than a string one; so building the variable-name list used to push that `Expr` straight into `array_intersect()` is going to blow up

Suggested by PHPStan.
