### PR TITLE
feat: allow filtering logged mutant types via --log-verbosity

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -336,7 +336,9 @@ final class RunCommand extends BaseCommand
                 self::OPTION_LOG_VERBOSITY,
                 null,
                 InputOption::VALUE_REQUIRED,
-                '"all" - full logs format, "default" - short logs format, "none" - no logs',
+                '"all" - full logs format, "default" - short logs format, "none" - no logs. '
+                . 'Also accepts a comma-separated list of mutant types with an optional "+" (include) or "-" (exclude) '
+                . 'prefix, applied on top of "default", e.g. "default,-timeout" or "none,+escaped,+timeout".',
                 Container::DEFAULT_LOG_VERBOSITY,
             );
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -43,12 +43,14 @@ use Infection\Configuration\Entry\PhpStan;
 use Infection\Configuration\Entry\PhpUnit;
 use Infection\Configuration\Entry\Source;
 use Infection\Configuration\SourceFilter\SourceFilter;
+use Infection\Console\LogVerbosity;
 use Infection\Mutator\Mutator;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
 use Infection\TestFramework\TestFrameworkTypes;
 use function is_string;
 use function ltrim;
 use PhpParser\Node;
+use function sprintf;
 use Webmozart\Assert\Assert;
 
 /**
@@ -57,12 +59,6 @@ use Webmozart\Assert\Assert;
  */
 readonly class Configuration
 {
-    private const array LOG_VERBOSITY = [
-        'all',
-        'none',
-        'default',
-    ];
-
     /**
      * @param array<string, Mutator<Node>> $mutators
      * @param array<string, array<int, string>> $ignoreSourceCodeMutatorsMap
@@ -113,7 +109,10 @@ readonly class Configuration
     ) {
         Assert::nullOrGreaterThanEq($processTimeout, 0);
         Assert::allIsInstanceOf($mutators, Mutator::class);
-        Assert::oneOf($logVerbosity, self::LOG_VERBOSITY);
+        Assert::true(
+            LogVerbosity::isValidOption($logVerbosity),
+            sprintf('Invalid "--log-verbosity" option "%s".', $logVerbosity),
+        );
         Assert::oneOf($testFramework, TestFrameworkTypes::getTypes());
         Assert::nullOrOneOf($staticAnalysisTool, StaticAnalysisToolTypes::getTypes());
         Assert::nullOrGreaterThanEq($minMsi, 0.);

--- a/src/Console/LogVerbosity.php
+++ b/src/Console/LogVerbosity.php
@@ -35,10 +35,18 @@ declare(strict_types=1);
 
 namespace Infection\Console;
 
+use function array_filter;
 use function array_key_exists;
+use function array_values;
+use function explode;
 use function in_array;
 use Infection\CannotBeInstantiated;
+use Infection\Mutant\DetectionStatus;
+use InvalidArgumentException;
+use function sprintf;
+use function substr;
 use Symfony\Component\Console\Input\InputInterface;
+use function trim;
 
 /**
  * @internal
@@ -77,11 +85,59 @@ final class LogVerbosity
         self::NONE_INTEGER => self::NONE,
     ];
 
+    /**
+     * Map of a slug (as accepted by `--log-verbosity`) to the corresponding {@see DetectionStatus}.
+     *
+     * @var array<string, DetectionStatus>
+     */
+    public const array STATUS_SLUGS = [
+        'escaped' => DetectionStatus::ESCAPED,
+        'timed-out' => DetectionStatus::TIMED_OUT,
+        'timeout' => DetectionStatus::TIMED_OUT,
+        'skipped' => DetectionStatus::SKIPPED,
+        'killed' => DetectionStatus::KILLED_BY_TESTS,
+        'killed-sa' => DetectionStatus::KILLED_BY_STATIC_ANALYSIS,
+        'error' => DetectionStatus::ERROR,
+        'errors' => DetectionStatus::ERROR,
+        'syntax-error' => DetectionStatus::SYNTAX_ERROR,
+        'not-covered' => DetectionStatus::NOT_COVERED,
+        'ignored' => DetectionStatus::IGNORED,
+    ];
+
+    /**
+     * Statuses displayed by default (i.e. when `--log-verbosity=default`).
+     *
+     * @var array<int, DetectionStatus>
+     */
+    public const array DEFAULT_STATUSES = [
+        DetectionStatus::ESCAPED,
+        DetectionStatus::TIMED_OUT,
+        DetectionStatus::SKIPPED,
+        DetectionStatus::NOT_COVERED,
+    ];
+
+    /**
+     * Statuses displayed when `--log-verbosity=all`.
+     *
+     * @var array<int, DetectionStatus>
+     */
+    public const array ALL_STATUSES = [
+        DetectionStatus::ESCAPED,
+        DetectionStatus::TIMED_OUT,
+        DetectionStatus::SKIPPED,
+        DetectionStatus::KILLED_BY_TESTS,
+        DetectionStatus::KILLED_BY_STATIC_ANALYSIS,
+        DetectionStatus::ERROR,
+        DetectionStatus::SYNTAX_ERROR,
+        DetectionStatus::NOT_COVERED,
+        DetectionStatus::IGNORED,
+    ];
+
     public static function convertVerbosityLevel(InputInterface $input, ConsoleOutput $io): void
     {
         $verbosityLevel = $input->getOption('log-verbosity');
 
-        if (in_array($verbosityLevel, self::ALLOWED_OPTIONS, true)) {
+        if (in_array($verbosityLevel, self::ALLOWED_OPTIONS, true) || self::isValidOption((string) $verbosityLevel)) {
             return;
         }
 
@@ -97,5 +153,110 @@ final class LogVerbosity
 
         $io->logUnknownVerbosityOption(self::NORMAL);
         $input->setOption('log-verbosity', self::NORMAL);
+    }
+
+    public static function isValidOption(string $option): bool
+    {
+        if (in_array($option, [self::DEBUG, self::NONE, self::NORMAL], true)) {
+            return true;
+        }
+
+        foreach (explode(',', $option) as $token) {
+            $token = trim($token);
+
+            if ($token === '') {
+                continue;
+            }
+
+            $sign = $token[0];
+            $core = $sign === '+' || $sign === '-' ? substr($token, 1) : $token;
+
+            if (in_array($core, [self::DEBUG, self::NONE, self::NORMAL], true)) {
+                continue;
+            }
+
+            if (!array_key_exists($core, self::STATUS_SLUGS)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolves the `--log-verbosity` option into the list of {@see DetectionStatus} values to display.
+     *
+     * The `all`, `default` and `none` shorthands are kept for backward compatibility. Any other value is
+     * interpreted as a comma-separated list of status slugs (see {@see self::STATUS_SLUGS}) where each
+     * slug can be prefixed with `+` (include, the default) or `-` (exclude). The list is applied on top of
+     * the `default` set, e.g. `default,-timeout` or `none,+escaped,+timeout`.
+     *
+     * @return array<int, DetectionStatus>
+     */
+    public static function resolveDisplayedStatuses(string $option): array
+    {
+        if ($option === self::DEBUG) {
+            return self::ALL_STATUSES;
+        }
+
+        if ($option === self::NONE) {
+            return [];
+        }
+
+        if ($option === self::NORMAL) {
+            return self::DEFAULT_STATUSES;
+        }
+
+        $statuses = self::DEFAULT_STATUSES;
+
+        foreach (explode(',', $option) as $token) {
+            $token = trim($token);
+
+            if ($token === '') {
+                continue;
+            }
+
+            $sign = $token[0];
+            $core = $sign === '+' || $sign === '-' ? substr($token, 1) : $token;
+
+            if ($core === self::DEBUG) {
+                $statuses = self::ALL_STATUSES;
+
+                continue;
+            }
+
+            if ($core === self::NONE) {
+                $statuses = [];
+
+                continue;
+            }
+
+            if ($core === self::NORMAL) {
+                $statuses = self::DEFAULT_STATUSES;
+
+                continue;
+            }
+
+            if (!array_key_exists($core, self::STATUS_SLUGS)) {
+                throw new InvalidArgumentException(sprintf('Unknown "--log-verbosity" status "%s".', $core));
+            }
+
+            $status = self::STATUS_SLUGS[$core];
+
+            if ($sign === '-') {
+                $statuses = array_values(array_filter(
+                    $statuses,
+                    static fn (DetectionStatus $current): bool => $current !== $status,
+                ));
+
+                continue;
+            }
+
+            if (!in_array($status, $statuses, true)) {
+                $statuses[] = $status;
+            }
+        }
+
+        return $statuses;
     }
 }

--- a/src/Reporter/BaseTextFileReporter.php
+++ b/src/Reporter/BaseTextFileReporter.php
@@ -38,8 +38,11 @@ namespace Infection\Reporter;
 use function array_map;
 use function explode;
 use function implode;
+use function in_array;
+use Infection\Console\LogVerbosity;
 use Infection\Framework\Str;
 use Infection\Metrics\ResultsCollector;
+use Infection\Mutant\DetectionStatus;
 use Infection\Mutant\MutantExecutionResult;
 use const PHP_EOL;
 use function sprintf;
@@ -49,17 +52,24 @@ use function sprintf;
  */
 abstract readonly class BaseTextFileReporter implements LineMutationTestingResultsReporter
 {
+    /**
+     * @param array<int, DetectionStatus>|null $displayedStatuses
+     */
     public function __construct(
         private ResultsCollector $resultsCollector,
         private bool $debugVerbosity,
         private bool $onlyCoveredMode,
         private bool $debugMode,
+        private ?array $displayedStatuses = null,
     ) {
     }
 
     public function getLines(): array
     {
         $separateSections = false;
+
+        $displayedStatuses = $this->displayedStatuses
+            ?? ($this->debugVerbosity ? LogVerbosity::ALL_STATUSES : LogVerbosity::DEFAULT_STATUSES);
 
         $logs = [];
 
@@ -80,43 +90,55 @@ abstract readonly class BaseTextFileReporter implements LineMutationTestingResul
             $logs[] = '';
         }
 
-        $logs[] = $this->getResultsLine(
-            $this->resultsCollector->getEscapedExecutionResults(),
-            'Escaped',
-            $separateSections,
-        );
+        if (in_array(DetectionStatus::ESCAPED, $displayedStatuses, true)) {
+            $logs[] = $this->getResultsLine(
+                $this->resultsCollector->getEscapedExecutionResults(),
+                'Escaped',
+                $separateSections,
+            );
+        }
 
-        $logs[] = $this->getResultsLine(
-            $this->resultsCollector->getTimedOutExecutionResults(),
-            'Timed Out',
-            $separateSections,
-        );
+        if (in_array(DetectionStatus::TIMED_OUT, $displayedStatuses, true)) {
+            $logs[] = $this->getResultsLine(
+                $this->resultsCollector->getTimedOutExecutionResults(),
+                'Timed Out',
+                $separateSections,
+            );
+        }
 
-        $logs[] = $this->getResultsLine(
-            $this->resultsCollector->getSkippedExecutionResults(),
-            'Skipped',
-            $separateSections,
-        );
+        if (in_array(DetectionStatus::SKIPPED, $displayedStatuses, true)) {
+            $logs[] = $this->getResultsLine(
+                $this->resultsCollector->getSkippedExecutionResults(),
+                'Skipped',
+                $separateSections,
+            );
+        }
 
-        if ($this->debugVerbosity) {
+        if (in_array(DetectionStatus::KILLED_BY_TESTS, $displayedStatuses, true)) {
             $logs[] = $this->getResultsLine(
                 $this->resultsCollector->getKilledExecutionResults(),
                 'Killed by Test Framework',
                 $separateSections,
             );
+        }
 
+        if (in_array(DetectionStatus::KILLED_BY_STATIC_ANALYSIS, $displayedStatuses, true)) {
             $logs[] = $this->getResultsLine(
                 $this->resultsCollector->getKilledByStaticAnalysisExecutionResults(),
                 'Killed by Static Analysis',
                 $separateSections,
             );
+        }
 
+        if (in_array(DetectionStatus::ERROR, $displayedStatuses, true)) {
             $logs[] = $this->getResultsLine(
                 $this->resultsCollector->getErrorExecutionResults(),
                 'Errors',
                 $separateSections,
             );
+        }
 
+        if (in_array(DetectionStatus::SYNTAX_ERROR, $displayedStatuses, true)) {
             $logs[] = $this->getResultsLine(
                 $this->resultsCollector->getSyntaxErrorExecutionResults(),
                 'Syntax Errors',
@@ -124,7 +146,9 @@ abstract readonly class BaseTextFileReporter implements LineMutationTestingResul
             );
         }
 
-        if (!$this->onlyCoveredMode) {
+        if (!$this->onlyCoveredMode
+            && in_array(DetectionStatus::NOT_COVERED, $displayedStatuses, true)
+        ) {
             $logs[] = $this->getResultsLine(
                 $this->resultsCollector->getNotCoveredExecutionResults(),
                 'Not Covered',

--- a/src/Reporter/FileReporterFactory.php
+++ b/src/Reporter/FileReporterFactory.php
@@ -35,10 +35,12 @@ declare(strict_types=1);
 
 namespace Infection\Reporter;
 
+use function in_array;
 use Infection\Configuration\Entry\Logs;
 use Infection\Console\LogVerbosity;
 use Infection\Metrics\MetricsCalculator;
 use Infection\Metrics\ResultsCollector;
+use Infection\Mutant\DetectionStatus;
 use Infection\Reporter\Html\HtmlFileReporter;
 use Infection\Reporter\Html\StrykerHtmlReportBuilder;
 use Psr\Log\LoggerInterface;
@@ -133,23 +135,29 @@ class FileReporterFactory
 
     private function createTextLogger(Logs $logConfig): LineMutationTestingResultsReporter
     {
+        $displayedStatuses = LogVerbosity::resolveDisplayedStatuses($this->logVerbosity);
+        $debugVerbosity = in_array(DetectionStatus::KILLED_BY_TESTS, $displayedStatuses, true)
+            || in_array(DetectionStatus::ERROR, $displayedStatuses, true);
+
         if (
             $logConfig->getUseGitHubAnnotationsLogger()
             && $logConfig->getTextLogFilePath() === 'php://stdout'
         ) {
             return new GitHubActionsLogTextFileReporter(
                 $this->resultsCollector,
-                $this->logVerbosity === LogVerbosity::DEBUG,
+                $debugVerbosity,
                 $this->onlyCoveredCode,
                 $this->debugMode,
+                $displayedStatuses,
             );
         }
 
         return new TextFileReporter(
             $this->resultsCollector,
-            $this->logVerbosity === LogVerbosity::DEBUG,
+            $debugVerbosity,
             $this->onlyCoveredCode,
             $this->debugMode,
+            $displayedStatuses,
         );
     }
 

--- a/tests/phpunit/Console/LogVerbosityTest.php
+++ b/tests/phpunit/Console/LogVerbosityTest.php
@@ -37,6 +37,8 @@ namespace Infection\Tests\Console;
 
 use Infection\Console\ConsoleOutput;
 use Infection\Console\LogVerbosity;
+use Infection\Mutant\DetectionStatus;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -95,6 +97,104 @@ final class LogVerbosityTest extends TestCase
         ;
 
         LogVerbosity::convertVerbosityLevel($this->inputMock, $this->consoleOutputMock);
+    }
+
+    public function test_it_keeps_a_valid_list_option_without_changing_it(): void
+    {
+        $this->setInputExpectationsWhenItDoesNotChange('default,-timeout');
+
+        $this->consoleOutputMock
+            ->expects($this->never())
+            ->method($this->anything())
+        ;
+
+        LogVerbosity::convertVerbosityLevel($this->inputMock, $this->consoleOutputMock);
+    }
+
+    #[DataProvider('isValidOptionProvider')]
+    #[AllowMockObjectsWithoutExpectations]
+    public function test_it_validates_options(string $option, bool $expected): void
+    {
+        $this->assertSame($expected, LogVerbosity::isValidOption($option));
+    }
+
+    /**
+     * @param array<int, DetectionStatus> $expected
+     */
+    #[DataProvider('resolveDisplayedStatusesProvider')]
+    #[AllowMockObjectsWithoutExpectations]
+    public function test_it_resolves_displayed_statuses(string $option, array $expected): void
+    {
+        $this->assertSame($expected, LogVerbosity::resolveDisplayedStatuses($option));
+    }
+
+    public static function isValidOptionProvider(): iterable
+    {
+        yield 'all' => ['all', true];
+
+        yield 'default' => ['default', true];
+
+        yield 'none' => ['none', true];
+
+        yield 'default minus timeout' => ['default,-timeout', true];
+
+        yield 'none plus escaped and timeout' => ['none,+escaped,+timeout', true];
+
+        yield 'unknown slug' => ['default,baz', false];
+
+        yield 'only unknown slugs' => ['foo,bar', false];
+
+        yield 'legacy integer string' => ['1', false];
+    }
+
+    public static function resolveDisplayedStatusesProvider(): iterable
+    {
+        yield 'all' => ['all', LogVerbosity::ALL_STATUSES];
+
+        yield 'default' => ['default', LogVerbosity::DEFAULT_STATUSES];
+
+        yield 'none' => ['none', []];
+
+        yield 'default minus timeout' => [
+            'default,-timeout',
+            [
+                DetectionStatus::ESCAPED,
+                DetectionStatus::SKIPPED,
+                DetectionStatus::NOT_COVERED,
+            ],
+        ];
+
+        yield 'none plus escaped and timeout' => [
+            'none,+escaped,+timeout',
+            [
+                DetectionStatus::ESCAPED,
+                DetectionStatus::TIMED_OUT,
+            ],
+        ];
+
+        yield 'default plus errors' => [
+            'default,+errors',
+            [
+                DetectionStatus::ESCAPED,
+                DetectionStatus::TIMED_OUT,
+                DetectionStatus::SKIPPED,
+                DetectionStatus::NOT_COVERED,
+                DetectionStatus::ERROR,
+            ],
+        ];
+
+        yield 'all minus killed and error' => [
+            'all,-killed,-error',
+            [
+                DetectionStatus::ESCAPED,
+                DetectionStatus::TIMED_OUT,
+                DetectionStatus::SKIPPED,
+                DetectionStatus::KILLED_BY_STATIC_ANALYSIS,
+                DetectionStatus::SYNTAX_ERROR,
+                DetectionStatus::NOT_COVERED,
+                DetectionStatus::IGNORED,
+            ],
+        ];
     }
 
     public static function convertedLogVerbosityProvider(): iterable

--- a/tests/phpunit/Reporter/TextFileReporterTest.php
+++ b/tests/phpunit/Reporter/TextFileReporterTest.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Reporter;
 
+use function implode;
 use Infection\Metrics\ResultsCollector;
+use Infection\Mutant\DetectionStatus;
 use Infection\Reporter\TextFileReporter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -79,6 +81,61 @@ final class TextFileReporterTest extends TestCase
         );
 
         $this->assertReportedContentIs($expectedContents, $reporter);
+    }
+
+    /**
+     * @param array<int, DetectionStatus> $displayedStatuses
+     * @param array<string> $expectedSections
+     * @param array<string> $unexpectedSections
+     */
+    #[DataProvider('filteredStatusesProvider')]
+    public function test_it_only_reports_the_requested_statuses(
+        array $displayedStatuses,
+        bool $debugVerbosity,
+        array $expectedSections,
+        array $unexpectedSections,
+    ): void {
+        $reporter = new TextFileReporter(
+            self::createCompleteResultsCollector(),
+            $debugVerbosity,
+            false,
+            false,
+            $displayedStatuses,
+        );
+
+        $output = implode("\n", $reporter->getLines());
+
+        foreach ($expectedSections as $section) {
+            $this->assertStringContainsString($section, $output);
+        }
+
+        foreach ($unexpectedSections as $section) {
+            $this->assertStringNotContainsString($section, $output);
+        }
+    }
+
+    public static function filteredStatusesProvider(): iterable
+    {
+        yield 'only escaped and timed out' => [
+            [DetectionStatus::ESCAPED, DetectionStatus::TIMED_OUT],
+            false,
+            ['Escaped mutants:', 'Timed Out mutants:'],
+            ['Skipped mutants:', 'Killed by Test Framework mutants:', 'Not Covered mutants:'],
+        ];
+
+        yield 'only errors with debug verbosity' => [
+            [DetectionStatus::ERROR],
+            true,
+            ['Errors mutants:', '  process output'],
+            ['Escaped mutants:', 'Timed Out mutants:'],
+        ];
+
+        yield 'none' => [
+            [],
+            false,
+            [],
+            ['Escaped mutants:', 'Timed Out mutants:', 'Skipped mutants:'],
+        ];
     }
 
     public static function emptyMetricsProvider(): iterable


### PR DESCRIPTION
## Summary

Closes #2445

This extends the `--log-verbosity` option so you can choose exactly which mutant types end up in the text log, instead of only the `all` / `default` / `none` presets.

`--log-verbosity` now also accepts a comma separated list of mutant-type slugs. Each slug can be prefixed with `+` (include) or `-` (exclude) and the list is applied on top of the `default` set, for example:

- `default,-timeout` — everything except timed-out mutants
- `none,+escaped,+timeout` — only escaped and timed-out mutants
- `all,-killed,-error` — full detail minus killed-by-tests and errors

Available slugs: `escaped`, `timed-out` (alias `timeout`), `skipped`, `killed`, `killed-sa`, `error` (alias `errors`), `syntax-error`, `not-covered`, `ignored`.

The `all`, `default` and `none` shorthands keep their existing behavior, so this is fully backward compatible.

## How it works

- `LogVerbosity` gains `resolveDisplayedStatuses()` / `isValidOption()` which parse the option into a `DetectionStatus[]` set.
- `BaseTextFileReporter` renders only the statuses present in that set (the `only-covered` gate for `not-covered` is preserved).
- Process output and the "use `--log-verbosity=all`" note are still shown whenever a debug-level status (killed/error) is part of the set, matching the previous `all` behavior.

## Test plan

- [x] Unit tests for `LogVerbosity::resolveDisplayedStatuses` / `isValidOption`
- [x] `TextFileReporterTest` covers status filtering
- [x] Existing reporter/config/command suites (1338 tests) pass

I verified the change locally with PHP 8.5 + the project's PHPUnit suite.