### PR TITLE
refactor(mutator): Use PhpParser\Modifiers instead of deprecated ::MODIFIER_* constants

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -352,42 +352,6 @@ parameters:
 			path: ../src/Mutator/Extensions/MBString.php
 
 		-
-			rawMessage: '''
-				Fetching deprecated class constant MODIFIER_PRIVATE of class PhpParser\Node\Stmt\Class_:
-				Use Modifiers::PRIVATE instead
-			'''
-			identifier: classConstant.deprecated
-			count: 1
-			path: ../src/Mutator/FunctionSignature/ProtectedVisibility.php
-
-		-
-			rawMessage: '''
-				Fetching deprecated class constant MODIFIER_PROTECTED of class PhpParser\Node\Stmt\Class_:
-				Use Modifiers::PROTECTED instead
-			'''
-			identifier: classConstant.deprecated
-			count: 1
-			path: ../src/Mutator/FunctionSignature/ProtectedVisibility.php
-
-		-
-			rawMessage: '''
-				Fetching deprecated class constant MODIFIER_PROTECTED of class PhpParser\Node\Stmt\Class_:
-				Use Modifiers::PROTECTED instead
-			'''
-			identifier: classConstant.deprecated
-			count: 1
-			path: ../src/Mutator/FunctionSignature/PublicVisibility.php
-
-		-
-			rawMessage: '''
-				Fetching deprecated class constant MODIFIER_PUBLIC of class PhpParser\Node\Stmt\Class_:
-				Use Modifiers::PUBLIC instead
-			'''
-			identifier: classConstant.deprecated
-			count: 1
-			path: ../src/Mutator/FunctionSignature/PublicVisibility.php
-
-		-
 			rawMessage: 'Call to function array_filter() requires parameter #2 to be passed to avoid loose comparison semantics.'
 			identifier: arrayFilter.strict
 			count: 1

--- a/src/Mutator/FunctionSignature/ProtectedVisibility.php
+++ b/src/Mutator/FunctionSignature/ProtectedVisibility.php
@@ -41,6 +41,7 @@ use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
 use Infection\Reflection\Visibility;
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use Webmozart\Assert\Assert;
 
@@ -77,7 +78,7 @@ final class ProtectedVisibility implements Mutator
         yield new Node\Stmt\ClassMethod(
             $node->name,
             [
-                'flags' => ($node->flags & ~Node\Stmt\Class_::MODIFIER_PROTECTED) | Node\Stmt\Class_::MODIFIER_PRIVATE,
+                'flags' => ($node->flags & ~Modifiers::PROTECTED) | Modifiers::PRIVATE,
                 'byRef' => $node->returnsByRef(),
                 'params' => $node->getParams(),
                 'returnType' => $node->getReturnType(),

--- a/src/Mutator/FunctionSignature/PublicVisibility.php
+++ b/src/Mutator/FunctionSignature/PublicVisibility.php
@@ -41,6 +41,7 @@ use Infection\Mutator\Mutator;
 use Infection\Mutator\MutatorCategory;
 use Infection\PhpParser\Visitor\ReflectionVisitor;
 use Infection\Reflection\Visibility;
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use Webmozart\Assert\Assert;
 
@@ -76,7 +77,7 @@ final class PublicVisibility implements Mutator
         yield new Node\Stmt\ClassMethod(
             $node->name,
             [
-                'flags' => ($node->flags & ~Node\Stmt\Class_::MODIFIER_PUBLIC) | Node\Stmt\Class_::MODIFIER_PROTECTED,
+                'flags' => ($node->flags & ~Modifiers::PUBLIC) | Modifiers::PROTECTED,
                 'byRef' => $node->returnsByRef(),
                 'params' => $node->getParams(),
                 'returnType' => $node->getReturnType(),


### PR DESCRIPTION

Extracted from #3429