### PR TITLE
refactor(reporter): Add precise PHPDoc types to StrykerHtmlReportBuilder

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -547,36 +547,6 @@ parameters:
 			path: ../src/Reflection/CoreClassReflection.php
 
 		-
-			rawMessage: 'Method Infection\Reporter\Html\StrykerHtmlReportBuilder::build() return type has no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
-
-		-
-			rawMessage: 'Method Infection\Reporter\Html\StrykerHtmlReportBuilder::getFiles() return type with generic class ArrayObject does not specify its types: TKey, TValue'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
-
-		-
-			rawMessage: 'Method Infection\Reporter\Html\StrykerHtmlReportBuilder::getTestFiles() return type with generic class ArrayObject does not specify its types: TKey, TValue'
-			identifier: missingType.generics
-			count: 1
-			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
-
-		-
-			rawMessage: 'Method Infection\Reporter\Html\StrykerHtmlReportBuilder::retrieveMutants() return type has no value type specified in iterable type array.'
-			identifier: missingType.iterableValue
-			count: 1
-			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
-
-		-
-			rawMessage: 'Offset ''name'' might not exist on array{}|array{0: non-falsy-string, name: non-falsy-string, 1: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}.'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: ../src/Reporter/Html/StrykerHtmlReportBuilder.php
-
-		-
 			rawMessage: Infection\Reporter\Http\StrykerCurlClient should not exist
 			identifier: phpat.testConcreteSourceClassesHaveTests
 			count: 1

--- a/src/Reporter/Html/StrykerHtmlReportBuilder.php
+++ b/src/Reporter/Html/StrykerHtmlReportBuilder.php
@@ -334,7 +334,7 @@ final readonly class StrykerHtmlReportBuilder
         $matches = [];
 
         if (preg_match('/(?<name>\S+::\S+)(?<dataname> with data set (?:#\d+|"[^"]+"))?/', $processOutput, $matches) === 1) {
-            Assert::keyExists($matches, 'name', 'The regex has a mandatory capture group; its absence indicates the pattern above was changed without updating this code.');
+            Assert::keyExists($matches, 'name');
 
             return [$this->buildTestMethodId($matches['name'] . ($matches['dataname'] ?? ''))];
         }

--- a/src/Reporter/Html/StrykerHtmlReportBuilder.php
+++ b/src/Reporter/Html/StrykerHtmlReportBuilder.php
@@ -101,6 +101,15 @@ final readonly class StrykerHtmlReportBuilder
     ) {
     }
 
+    /**
+     * @return array{
+     *     schemaVersion: string,
+     *     thresholds: array{high: int, low: int},
+     *     files: ArrayObject<string, array<mixed>|string>,
+     *     testFiles: ArrayObject<array-key, array{tests: non-empty-list<array{id: string, name: string}>}>,
+     *     framework: array{name: string, branding: array{homepageUrl: string, imageUrl: string}},
+     * }
+     */
     public function build(): array
     {
         return [
@@ -121,6 +130,9 @@ final readonly class StrykerHtmlReportBuilder
         ];
     }
 
+    /**
+     * @return ArrayObject<array-key, array{tests: non-empty-list<array{id: string, name: string}>}>
+     */
     private function getTestFiles(): ArrayObject
     {
         $testFiles = [];
@@ -156,9 +168,13 @@ final readonly class StrykerHtmlReportBuilder
             }
         }
 
+        /** @var array<array-key, array{tests: non-empty-list<array{id: string, name: string}>}> $testFiles */
         return new ArrayObject($testFiles);
     }
 
+    /**
+     * @return ArrayObject<string, array<mixed>|string>
+     */
     private function getFiles(): ArrayObject
     {
         $files = new ArrayObject();
@@ -179,7 +195,7 @@ final readonly class StrykerHtmlReportBuilder
     }
 
     /**
-     * @param array<string, MutantExecutionResult[]> $resultsByPath
+     * @param array<string, list<MutantExecutionResult>> $resultsByPath
      *
      * @return ArrayObject<string, array<mixed>|string>
      */
@@ -211,7 +227,7 @@ final readonly class StrykerHtmlReportBuilder
     }
 
     /**
-     * @return array<string, MutantExecutionResult[]>
+     * @return array<string, list<MutantExecutionResult>>
      */
     private function retrieveResultsByPath(): array
     {
@@ -225,7 +241,20 @@ final readonly class StrykerHtmlReportBuilder
     }
 
     /**
-     * @param MutantExecutionResult[] $results
+     * @param list<MutantExecutionResult> $results
+     *
+     * @return list<array{
+     *     id: string,
+     *     mutatorName: string,
+     *     replacement: string,
+     *     description: string,
+     *     location: array{start: array{line: int, column: int}, end: array{line: int, column: int}},
+     *     status: string,
+     *     statusReason: string,
+     *     coveredBy: array<array-key, string>,
+     *     killedBy: array<int, string>,
+     *     testsCompleted: int,
+     * }>
      */
     private function retrieveMutants(array $results, string $originalCode): array
     {
@@ -305,6 +334,8 @@ final readonly class StrykerHtmlReportBuilder
         $matches = [];
 
         if (preg_match('/(?<name>\S+::\S+)(?<dataname> with data set (?:#\d+|"[^"]+"))?/', $processOutput, $matches) === 1) {
+            Assert::keyExists($matches, 'name', 'The regex has a mandatory capture group; its absence indicates the pattern above was changed without updating this code.');
+
             return [$this->buildTestMethodId($matches['name'] . ($matches['dataname'] ?? ''))];
         }
 


### PR DESCRIPTION

### Description

Specifies array shapes and generic types for `build()`, `getFiles(),` and `getTestFiles()` so PHPStan no longer needs baseline entries for missing generic/iterable value types.
