### PR TITLE
refactor: Remove deprecated FileOrDirectoryNotFound::multipleFilesDoNotExist()

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -3020,12 +3020,6 @@ count = 1
 
 [[issues]]
 file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator::locate`.'
 count = 1
@@ -3184,12 +3178,6 @@ count = 1
 file = "src/TestFramework/Common/VersionParser.php"
 code = "possibly-null-array-access"
 message = "Cannot perform array access on possibly `null` value."
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Config/TestFrameworkConfigLocator.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
 count = 1
 
 [[issues]]
@@ -4426,12 +4414,6 @@ count = 1
 file = "tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php"
 code = "string-member-selector"
 message = "This member selector uses a non-literal string type (`string`); its specific value cannot be statically determined."
-count = 1
-
-[[issues]]
-file = "tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php"
-code = "deprecated-method"
-message = 'Call to deprecated method: `Infection\FileSystem\Locator\FileOrDirectoryNotFound::multipleFilesDoNotExist`.'
 count = 1
 
 [[issues]]

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -607,12 +607,6 @@ parameters:
 			path: ../src/Source/Collector/GitDiffSourceCollector.php
 
 		-
-			rawMessage: 'Call to deprecated method multipleFilesDoNotExist() of class Infection\FileSystem\Locator\FileOrDirectoryNotFound.'
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
-
-		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
 			identifier: ternary.shortNotAllowed
 			count: 1
@@ -803,12 +797,6 @@ parameters:
 			identifier: phpat.testTestFrameworkCommonUtilitiesStayWithinFuturePackageBoundary
 			count: 1
 			path: ../src/TestFramework/Common/CommandLineBuilder.php
-
-		-
-			rawMessage: 'Call to deprecated method multipleFilesDoNotExist() of class Infection\FileSystem\Locator\FileOrDirectoryNotFound.'
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../src/TestFramework/Config/TestFrameworkConfigLocator.php
 
 		-
 			rawMessage: Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.
@@ -1199,12 +1187,6 @@ parameters:
 			identifier: method.dynamicName
 			count: 1
 			path: ../tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
-
-		-
-			rawMessage: 'Call to deprecated method multipleFilesDoNotExist() of class Infection\FileSystem\Locator\FileOrDirectoryNotFound.'
-			identifier: staticMethod.deprecated
-			count: 1
-			path: ../tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php
 
 		-
 			rawMessage: Infection\Tests\Logger\Console\BufferedOutputWithStdErrOutput should not exist

--- a/src/FileSystem/Locator/FileOrDirectoryNotFound.php
+++ b/src/FileSystem/Locator/FileOrDirectoryNotFound.php
@@ -62,22 +62,6 @@ final class FileOrDirectoryNotFound extends RuntimeException
     }
 
     /**
-     * @deprecated
-     *
-     * @param string[] $files
-     */
-    public static function multipleFilesDoNotExist(string $path, array $files): self
-    {
-        return new self(
-            sprintf(
-                'The path "%s" does not contain any of the requested files: "%s"',
-                $path,
-                implode('", "', $files),
-            ),
-        );
-    }
-
-    /**
      * @param string[] $files
      * @param string[] $roots
      */

--- a/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
+++ b/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
@@ -75,6 +75,6 @@ final readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigL
             $triedFiles[] = sprintf('%s.%s', $cliTool, $extension);
         }
 
-        throw FileOrDirectoryNotFound::multipleFilesDoNotExist($dir, $triedFiles);
+        throw FileOrDirectoryNotFound::fromFiles($triedFiles, [$dir]);
     }
 }

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -75,6 +75,6 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
             $triedFiles[] = sprintf('%s.%s', $cliTool, $extension);
         }
 
-        throw FileOrDirectoryNotFound::multipleFilesDoNotExist($dir, $triedFiles);
+        throw FileOrDirectoryNotFound::fromFiles($triedFiles, [$dir]);
     }
 }

--- a/tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php
+++ b/tests/phpunit/FileSystem/Locator/FileOrDirectoryNotFoundTest.php
@@ -76,18 +76,6 @@ final class FileOrDirectoryNotFoundTest extends TestCase
         $this->assertNull($exception->getPrevious());
     }
 
-    public function test_multiple_files_do_not_exist(): void
-    {
-        $exception = FileOrDirectoryNotFound::multipleFilesDoNotExist('foo/bar/', ['file1', 'file2']);
-
-        $this->assertSame(
-            'The path "foo/bar/" does not contain any of the requested files: "file1", "file2"',
-            $exception->getMessage(),
-        );
-        $this->assertSame(0, $exception->getCode());
-        $this->assertNull($exception->getPrevious());
-    }
-
     public static function nonExistentPathsProvider(): iterable
     {
         yield [

--- a/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
+++ b/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
@@ -57,7 +57,7 @@ final class StaticAnalysisConfigLocatorTest extends TestCase
         $this->expectException(FileOrDirectoryNotFound::class);
         $this->expectExceptionMessage(
             sprintf(
-                'The path "%s" does not contain any of the requested files: "phpstan.neon", "phpstan.neon.dist", "phpstan.dist.neon"',
+                'Could not locate the files "phpstan.neon", "phpstan.neon.dist", "phpstan.dist.neon", "phpstan.toml", "phpstan.json", "phpstan.yaml" in "%s"',
                 $dir,
             ),
         );

--- a/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -57,7 +57,7 @@ final class TestFrameworkConfigLocatorTest extends TestCase
         $this->expectException(FileOrDirectoryNotFound::class);
         $this->expectExceptionMessage(
             sprintf(
-                'The path "%s" does not contain any of the requested files: "phpunit.xml", "phpunit.yml", "phpunit.xml.dist", "phpunit.yml.dist", "phpunit.dist.xml", "phpunit.dist.yml"',
+                'Could not locate the files "phpunit.xml", "phpunit.yml", "phpunit.xml.dist", "phpunit.yml.dist", "phpunit.dist.xml", "phpunit.dist.yml", "phpunit.php" in "%s"',
                 $dir,
             ),
         );


### PR DESCRIPTION

## Description

It was deprecated for a while now. Let's get it done.

