### PR TITLE
fix(mago): Limit the mago thread count in the mutant processes

### DIFF
--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -119,8 +119,6 @@ readonly class Configuration
         Assert::nullOrGreaterThanEq($minMsi, 0.);
         Assert::greaterThanEq($threadCount, 0);
 
-        var_dump(LogVerbosity::resolveDisplayedStatuses($this->logVerbosity));die;
-
         if (is_string($dotsPerRow)) {
             Assert::same($dotsPerRow, 'max');
         } else {

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -119,6 +119,8 @@ readonly class Configuration
         Assert::nullOrGreaterThanEq($minMsi, 0.);
         Assert::greaterThanEq($threadCount, 0);
 
+        var_dump(LogVerbosity::resolveDisplayedStatuses($this->logVerbosity));die;
+
         if (is_string($dotsPerRow)) {
             Assert::same($dotsPerRow, 'max');
         } else {

--- a/src/StaticAnalysis/Mago/Process/MagoMutantProcessFactory.php
+++ b/src/StaticAnalysis/Mago/Process/MagoMutantProcessFactory.php
@@ -89,6 +89,7 @@ final readonly class MagoMutantProcessFactory implements LazyMutantProcessFactor
         $options = array_merge(
             [
                 '--colors=never',
+                '--threads=1',
                 'analyze',
                 '--reporting-format=short',
                 '--substitute',

--- a/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
+++ b/tests/phpunit/StaticAnalysis/Mago/Process/MagoMutantProcessFactoryTest.php
@@ -102,6 +102,7 @@ final class MagoMutantProcessFactoryTest extends TestCase
             ->method('build')
             ->with('/path/to/mago', [], [
                 '--colors=never',
+                '--threads=1',
                 'analyze',
                 '--reporting-format=short',
                 '--substitute',
@@ -184,6 +185,7 @@ final class MagoMutantProcessFactoryTest extends TestCase
             ->method('build')
             ->with('/path/to/mago', [], [
                 '--colors=never',
+                '--threads=1',
                 'analyze',
                 '--reporting-format=short',
                 '--substitute',
@@ -270,6 +272,7 @@ final class MagoMutantProcessFactoryTest extends TestCase
             ->method('build')
             ->with('/path/to/mago', [], [
                 '--colors=never',
+                '--threads=1',
                 'analyze',
                 '--reporting-format=short',
                 '--substitute',


### PR DESCRIPTION
## Description

This applies the same logic as https://github.com/infection/infection/pull/2169, i.e. limit the number of sub-processes spawned by mago for mutant processes. This is an attempt to fix #3476.

## Changes

- Limit the threads count to 1 for mago mutant processes.

## Related issues

Related to #3476.
