### PR TITLE
fix(phar): Upgrade Box so the PHAR works on PHP 8.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 # Variables
 #---------------------------------------------------------------------------
 BOX=./.tools/box
-BOX_URL="https://github.com/humbug/box/releases/download/4.5.1/box.phar"
+BOX_URL="https://github.com/humbug/box/releases/download/4.7.0/box.phar"
 
 PHP_CS_FIXER=./.tools/php-cs-fixer
 PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.92.5/php-cs-fixer.phar"


### PR DESCRIPTION
## Description

The PHAR fatals on PHP 8.5 with `Call to undefined function Infected\array_first()`.

Box 4.5.1 ships a PhpStorm stubs map that predates PHP 8.5, so PHP-Scoper does not recognise `array_first()` as a native function and prefixes it, both at the call site in `BaseReportLocator` and in the `symfony/polyfill-php85` bootstrap. That bootstrap returns early on PHP >= 8.5, so `Infected\array_first()` is never declared and the call blows up.

Box 4.7.0 knows the PHP 8.5 symbols, leaves `array_first()` unprefixed, and PHP-Scoper's global function aliases keep the polyfill reachable on older versions.

## Changes

- Upgrade Box from 4.5.1 to 4.7.0.

## Reviewer Notes

Verified locally by compiling the PHAR with both versions and running it on the `PHPUnit_12-5` e2e fixture with `--coverage=build/`, which is the path that reaches `BaseReportLocator::lookup()`: the 4.5.1 build reproduces the reported fatal on PHP 8.5, the 4.7.0 build completes. Also checked the 4.7.0 build still resolves `array_first()` on PHP 8.4, where it goes through the polyfill.

The PHAR e2e job only runs on PHP 8.3, so nothing in CI covers this yet.

## Related issues

Fixes https://github.com/infection/infection/issues/3494.
