### PR TITLE
build: Update the docker sandbox kits to the newer schema version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ sbx-create: sbx-image-build sbx-project-local-kit sbx-kit-validate
 	sbx run codex \
 		--template=infection-sbx-php-8.4:latest \
 		--kit=./devTools/sbx/kits/codex-otel \
-		--kit "git+https://github.com/docker/sbx-kits-contrib#ref=v0.9.0&dir=git-ssh-sign" . \
+		--kit="git+https://github.com/docker/sbx-kits-contrib#ref=1f2f62200d68b8e1f653730ab29134a1a06755db&dir=git-ssh-sign" . \
 		--kit=$(SBX_PROJECT_LOCAL_KIT)
 
 .PHONY: sbx-project-local-kit

--- a/devTools/sbx/README.md
+++ b/devTools/sbx/README.md
@@ -55,14 +55,17 @@ make _sbx-image-build
 To run a sandbox manually with the loaded template from the repository root:
 
 ```shell
+# In case the following gets outdated, you can check `make sbx-create`.
 sbx run codex \
   --template=infection-sbx-php-8.4:latest \
   --kit=./devTools/sbx/kits/codex-otel \
+  --kit="git+https://github.com/docker/sbx-kits-contrib#ref=1f2f62200d68b8e1f653730ab29134a1a06755db&dir=git-ssh-sign" \
   --kit=./devTools/sbx/kits/project-local
 ```
 
 The `--kit` flag only applies when the sandbox is created. For an existing
-sandbox, recreate it or apply the kit explicitly with `sbx kit add`.
+sandbox, recreate it. The Codex OTEL kit uses startup hooks and generated files
+that `sbx kit add` cannot apply to an existing sandbox.
 
 To add user-specific sandbox customisation, edit:
 

--- a/devTools/sbx/kits/codex-otel/spec.yaml
+++ b/devTools/sbx/kits/codex-otel/spec.yaml
@@ -4,8 +4,8 @@ name: infection-codex-otel
 displayName: Infection Codex OTEL
 description: Merge Infection OpenTelemetry settings into the generated Codex user config.
 
-commands:
-  initFiles:
+setup:
+  files:
     - path: /home/agent/.config/infection-sbx/workdir
       content: "${WORKDIR}\n"
       mode: "0644"


### PR DESCRIPTION
## Description

Docker sandbox released [0.38.0](https://github.com/docker/sbx-releases/releases/tag/v0.38.0) for which the kits use a new schema. Currently attempting to create the sandbox with `make sbx-create` fails with:

```
ERROR: resolve kits: kit "./devTools/sbx/kits/codex-otel": artifact: invalid spec.yaml: yaml: unmarshal errors:
  line 7: field commands not found in type spec.specFileV2
```

This PR fixes that.

As there is no CI for it at the moment, this was validated locally with `make sbx-kit-validate`.

## Changes

- Update the OTEL kit to the schema2.
- Update the `git-ssh-sign` sbx-kits-contrib kit to a newer version which migrated to that format.
