### PR TITLE
perf: Stop retaining every Mutation until the end of the run

### DIFF
--- a/src/Mutant/MutantFactory.php
+++ b/src/Mutant/MutantFactory.php
@@ -38,8 +38,8 @@ namespace Infection\Mutant;
 use Infection\Differ\Differ;
 use Infection\Mutation\Mutation;
 use Later\Interfaces\Deferred;
-use function Later\later;
 use function Later\lazy;
+use function Later\now;
 use function sprintf;
 
 /**
@@ -64,7 +64,7 @@ class MutantFactory
         );
 
         $mutatedCode = lazy($this->createMutatedCode($mutation));
-        $originalPrettyPrintedFile = later(static fn () => yield $mutation->getOriginalFileContent());
+        $originalPrettyPrintedFile = now($mutation->getOriginalFileContent());
 
         return new Mutant(
             $mutantFilePath,


### PR DESCRIPTION
## Description
In one of my projects, I upgraded Infection from 0.29.14 to 0.35.2, after that, the local run started dying with a PHP out-of-memory error **(with 128mb limit)**. Working through the diff between the two versions with Claude Code (Opus 5), looking for what could have affected memory consumption, and that search led to `MutantFactory` and its `create()` method. 

### What
`later(static fn () => yield $mutation->getOriginalFileContent())` wraps the original file content in a deferred closure that captures the whole Mutation object. This replaces it with `now($mutation->getOriginalFileContent())`, which wraps the string that is already in memory: the same `Later\Interfaces\Deferred` contract, but no closure and nothing captured.

### Why
The deferred used to wrap real work: pretty-printing the AST back into source (#1420). Since #2448 (0.32.0), the original content is stored verbatim, and Mutation::getOriginalFileContent() is a plain getter over a private readonly string. There is nothing left to defer, only a closure holding the Mutation.

## Numbers
Measured on my own project which contains 2051 mutations, runs with `--threads=6`. Using `Memory:` line in Infection's own output.

<details>
 <summary>infection.json5</summary>

 ```json5
{
    "$schema": "vendor/infection/infection/resources/schema.json",
    "source": {
        "directories": [
            "src"
        ]
    },
    "timeout": 10,
    "mutators": {
        "@default": true
    },
    "phpUnit": {
        "configDir": "."
    }
}
 ```
</details>

### Env 1. Windows, PHP 8.4 ZTS: 

| options | 0.29.14 | 0.35.2 (`later`) | 0.35.2 patched (`now`) |
|---|---|---|---|
| **with progress** `--dry-run` | 0.11 GB. | 0.20 GB | 0.20 GB |
| `--no-progress --dry-run`| 0.04 GB | 0.19 GB | **0.13 GB** |
| **with progress** |  0.16 GB | 0.21 GB | 0.21 GB |
| `--no-progress` | 0.12 GB | 0.20 GB | **0.14 GB** |

### Env 2. WSL2 Ubuntu, PHP 8.4 NTS + pcov

I didn't run the infection without the --dry-run option to keep the experiment running quickly.

| options | 0.29.14 | 0.35.2 (`later`) | 0.35.2 patched (`now`) |
|---|---|---|---|
| **with progress** `--dry-run` | 0.13 GB. | 0.22 GB | 0.22 GB |
| `--no-progress --dry-run`| 0.06 GB | 0.19 GB | **0.14 GB.** |

Different versions given different detection statuses on the same files. I think this could have affected the memory consumption results. Anyway, limit was reached, but seems better with patch. 

## Reviewer Notes

**You will not reproduce this on Infection repository with current config.** `infection.json5` sets `"global-ignoreSourceCodeByRegex": ["Assert::.*"]`. The `global-` prefix puts every mutator into `ignoreSourceCodeMutatorsMap`, so `MutationTestingRunner::ignoredByRegex()` calls `$mutant->getDiff()->get()` for every single mutant, which resolves the deferred and releases the `Mutation` immediately.


