### PR TITLE
refactor(test-framework): Extract retrieving the Composer bin directory into a dedicated method

### DIFF
--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -78,7 +78,7 @@ class TestFrameworkFinder
     {
         if (!array_key_exists($testFrameworkName, $this->cachedPath)) {
             if (!$this->shouldUseCustomPath($testFrameworkName, $customPath)) {
-                $this->addVendorBinToPath();
+                $this->addComposerBinToPath();
             }
 
             $this->cachedPath[$testFrameworkName] = realpath($this->findTestFramework($testFrameworkName, $customPath));
@@ -106,27 +106,13 @@ class TestFrameworkFinder
         throw FinderException::testCustomPathDoesNotExist($testFrameworkName, $customPath);
     }
 
-    private function addVendorBinToPath(): void
+    private function addComposerBinToPath(): void
     {
-        $vendorPath = null;
+        $composerBinDir = $this->getComposerBinDir();
 
-        try {
-            $vendorPath = $this->shellCommandRunner->mustRun([
-                ...$this->findComposer(),
-                'config',
-                'bin-dir',
-            ]);
-        } catch (RuntimeException) {
-            $candidate = getcwd() . '/vendor/bin';
-
-            if (file_exists($candidate)) {
-                $vendorPath = $candidate;
-            }
-        }
-
-        if ($vendorPath !== null) {
+        if ($composerBinDir !== null) {
             $pathName = getenv('PATH') !== false ? 'PATH' : 'Path';
-            putenv($pathName . '=' . $vendorPath . PATH_SEPARATOR . getenv($pathName));
+            putenv($pathName . '=' . $composerBinDir . PATH_SEPARATOR . getenv($pathName));
         }
     }
 
@@ -205,5 +191,26 @@ class TestFrameworkFinder
         }
 
         return $path;
+    }
+
+    private function getComposerBinDir(): ?string
+    {
+        $binDir = null;
+
+        try {
+            $binDir = $this->shellCommandRunner->mustRun([
+                ...$this->findComposer(),
+                'config',
+                'bin-dir',
+            ]);
+        } catch (RuntimeException) {
+            $candidate = getcwd() . '/vendor/bin';
+
+            if (file_exists($candidate)) {
+                $binDir = $candidate;
+            }
+        }
+
+        return $binDir;
     }
 }


### PR DESCRIPTION
Initially sketched out in #3318. This PR is a tiny preparatory refactoring step which will help to reduce the noise of the fix and also help with the readability of the code. It:

- Extract retrieving the Composer bin directory code from `TestFrameworkFinder::addVendorBinToPath()`.
- Rename "vendor bin path" to "composer bin path" to better reflect that the Composer bin path is not necessarily `vendor`.