### PR TITLE
refactor(Mutant): Simplify the prettyPrintedOriginalCode property type

### DIFF
--- a/src/Mutant/Mutant.php
+++ b/src/Mutant/Mutant.php
@@ -48,14 +48,13 @@ class Mutant
     /**
      * @param Deferred<string> $mutatedCode
      * @param Deferred<string> $diff
-     * @param Deferred<string> $prettyPrintedOriginalCode
      */
     public function __construct(
         private readonly string $mutantFilePath,
         private readonly Mutation $mutation,
         private readonly Deferred $mutatedCode,
         private readonly Deferred $diff,
-        private readonly Deferred $prettyPrintedOriginalCode,
+        private readonly string $prettyPrintedOriginalCode,
     ) {
     }
 
@@ -77,10 +76,7 @@ class Mutant
         return $this->mutatedCode;
     }
 
-    /**
-     * @return Deferred<string>
-     */
-    public function getPrettyPrintedOriginalCode(): Deferred
+    public function getPrettyPrintedOriginalCode(): string
     {
         return $this->prettyPrintedOriginalCode;
     }

--- a/src/Mutant/MutantExecutionResult.php
+++ b/src/Mutant/MutantExecutionResult.php
@@ -54,7 +54,6 @@ class MutantExecutionResult
 
     /**
      * @param Deferred<string> $mutantDiff
-     * @param Deferred<string> $originalCode
      * @param Deferred<string> $mutatedCode
      * @param TestLocation[] $tests
      */
@@ -71,7 +70,7 @@ class MutantExecutionResult
         private readonly int $originalEndingLine,
         private readonly int $originalStartFilePosition,
         private readonly int $originalEndFilePosition,
-        private readonly Deferred $originalCode,
+        private readonly string $originalCode,
         private readonly Deferred $mutatedCode,
         private readonly array $tests,
         private readonly float $processRuntime,
@@ -158,7 +157,7 @@ class MutantExecutionResult
 
     public function getOriginalCode(): string
     {
-        return $this->originalCode->get();
+        return $this->originalCode;
     }
 
     public function getMutatedCode(): string

--- a/src/Mutant/MutantFactory.php
+++ b/src/Mutant/MutantFactory.php
@@ -39,7 +39,6 @@ use Infection\Differ\Differ;
 use Infection\Mutation\Mutation;
 use Later\Interfaces\Deferred;
 use function Later\lazy;
-use function Later\now;
 use function sprintf;
 
 /**
@@ -64,7 +63,7 @@ class MutantFactory
         );
 
         $mutatedCode = lazy($this->createMutatedCode($mutation));
-        $originalPrettyPrintedFile = now($mutation->getOriginalFileContent());
+        $originalPrettyPrintedFile = $mutation->getOriginalFileContent();
 
         return new Mutant(
             $mutantFilePath,
@@ -82,13 +81,12 @@ class MutantFactory
     }
 
     /**
-     * @param Deferred<string> $originalPrettyPrintedFile
      * @param Deferred<string> $mutantCode
      *
      * @return iterable<string>
      */
-    private function createMutantDiff(Deferred $originalPrettyPrintedFile, Deferred $mutantCode): iterable
+    private function createMutantDiff(string $originalPrettyPrintedFile, Deferred $mutantCode): iterable
     {
-        yield $this->differ->diff($originalPrettyPrintedFile->get(), $mutantCode->get());
+        yield $this->differ->diff($originalPrettyPrintedFile, $mutantCode->get());
     }
 }

--- a/tests/phpunit/Metrics/CreateMutantExecutionResult.php
+++ b/tests/phpunit/Metrics/CreateMutantExecutionResult.php
@@ -97,7 +97,7 @@ trait CreateMutantExecutionResult
             10 + $id,
             $id,
             10 + $id,
-            now('<?php $a = 1;'),
+            '<?php $a = 1;',
             now('<?php $a = 1;'),
             [],
             0.0,

--- a/tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php
+++ b/tests/phpunit/Metrics/SortableMutantExecutionResultsTest.php
@@ -203,7 +203,7 @@ final class SortableMutantExecutionResultsTest extends TestCase
             $originalStartingLine + 10,
             1,
             5,
-            now('<?php $a = 1;'),
+            '<?php $a = 1;',
             now('<?php $a = 1;'),
             [],
             0.0,

--- a/tests/phpunit/Mutant/MutantAssertions.php
+++ b/tests/phpunit/Mutant/MutantAssertions.php
@@ -54,7 +54,7 @@ trait MutantAssertions
             expectedMutation: $expected->getMutation(),
             expectedMutatedCode: $expected->getMutatedCode()->get(),
             expectedDiff: $expected->getDiff()->get(),
-            expectedPrettyPrintedOriginalCode: $expected->getPrettyPrintedOriginalCode()->get(),
+            expectedPrettyPrintedOriginalCode: $expected->getPrettyPrintedOriginalCode(),
         );
     }
 
@@ -70,6 +70,6 @@ trait MutantAssertions
         $this->assertEquals($expectedMutation, $mutant->getMutation());
         $this->assertSame($expectedMutatedCode, $mutant->getMutatedCode()->get());
         $this->assertSame($expectedDiff, $mutant->getDiff()->get());
-        $this->assertSame($expectedPrettyPrintedOriginalCode, $mutant->getPrettyPrintedOriginalCode()->get());
+        $this->assertSame($expectedPrettyPrintedOriginalCode, $mutant->getPrettyPrintedOriginalCode());
     }
 }

--- a/tests/phpunit/Mutant/MutantBuilder.php
+++ b/tests/phpunit/Mutant/MutantBuilder.php
@@ -59,7 +59,7 @@ final class MutantBuilder
             $mutant->getMutation(),
             $mutant->getMutatedCode()->get(),
             $mutant->getDiff()->get(),
-            $mutant->getPrettyPrintedOriginalCode()->get(),
+            $mutant->getPrettyPrintedOriginalCode(),
         );
     }
 
@@ -201,7 +201,7 @@ final class MutantBuilder
             $this->mutation,
             now($this->mutatedCode),
             now($this->diff),
-            now($this->prettyPrintedOriginalCode),
+            $this->prettyPrintedOriginalCode,
         );
     }
 }

--- a/tests/phpunit/Mutant/MutantExecutionResultBuilder.php
+++ b/tests/phpunit/Mutant/MutantExecutionResultBuilder.php
@@ -48,7 +48,6 @@ final class MutantExecutionResultBuilder
 {
     /**
      * @param Deferred<string> $mutantDiff
-     * @param Deferred<string> $originalCode
      * @param Deferred<string> $mutatedCode
      * @param TestLocation[] $tests
      */
@@ -63,7 +62,7 @@ final class MutantExecutionResultBuilder
         private string $originalFilePath,
         private int $originalStartingLine,
         private int $originalEndingLine,
-        private Deferred $originalCode,
+        private string $originalCode,
         private Deferred $mutatedCode,
         private array $tests,
         private float $processRuntime,
@@ -83,7 +82,7 @@ final class MutantExecutionResultBuilder
             $result->getOriginalFilePath(),
             $result->getOriginalStartingLine(),
             $result->getOriginalEndingLine(),
-            now($result->getOriginalCode()),
+            $result->getOriginalCode(),
             now($result->getMutatedCode()),
             $result->getTests(),
             $result->getProcessRuntime(),
@@ -111,11 +110,9 @@ final class MutantExecutionResultBuilder
             originalFilePath: 'src/Foo.php',
             originalStartingLine: 10,
             originalEndingLine: 15,
-            originalCode: now(
-                <<<'PHP'
-                    <?php $a = 1;
-                    PHP,
-            ),
+            originalCode: <<<'PHP'
+                <?php $a = 1;
+                PHP,
             mutatedCode: now(
                 <<<'PHP'
                     <?php $a = 2;
@@ -156,24 +153,22 @@ final class MutantExecutionResultBuilder
             originalFilePath: '/path/to/src/Foo.php',
             originalStartingLine: 10,
             originalEndingLine: 15,
-            originalCode: now(
-                <<<'PHP'
-                    <?php
+            originalCode: <<<'PHP'
+                <?php
 
-                    namespace Acme;
+                namespace Acme;
 
-                    class Foo
+                class Foo
+                {
+                    public function bar(): void
                     {
-                        public function bar(): void
-                        {
-                            for ($i = 0; $i < 10; $i++) {
-                                echo $i;
-                            }
+                        for ($i = 0; $i < 10; $i++) {
+                            echo $i;
                         }
                     }
+                }
 
-                    PHP,
-            ),
+                PHP,
             mutatedCode: now(
                 <<<'PHP'
                     <?php
@@ -291,10 +286,7 @@ final class MutantExecutionResultBuilder
         return $clone;
     }
 
-    /**
-     * @param Deferred<string> $originalCode
-     */
-    public function withOriginalCode(Deferred $originalCode): self
+    public function withOriginalCode(string $originalCode): self
     {
         $clone = clone $this;
         $clone->originalCode = $originalCode;

--- a/tests/phpunit/Mutant/MutantFactoryTest.php
+++ b/tests/phpunit/Mutant/MutantFactoryTest.php
@@ -104,28 +104,11 @@ final class MutantFactoryTest extends TestCase
             $mutation,
             now('mutated code'),
             now('code diff'),
-            now('original code'),
+            'original code',
         );
 
         $mutant = $this->mutantFactory->create($mutation);
 
         $this->assertMutantEquals($expected, $mutant);
-    }
-
-    public function test_it_printing_the_original_file_is_memoized(): void
-    {
-        $mutation = MutationBuilder::withMinimalTestData()->build();
-
-        $this->differMock
-            ->expects($this->atLeastOnce())
-            ->method('diff')
-            ->willReturn('code diff')
-        ;
-
-        $this->mutantFactory->create($mutation)->getPrettyPrintedOriginalCode()->get();
-        $this->mutantFactory->create($mutation)->getDiff()->get();
-
-        $this->mutantFactory->create($mutation)->getPrettyPrintedOriginalCode()->get();
-        $this->mutantFactory->create($mutation)->getDiff()->get();
     }
 }

--- a/tests/phpunit/Mutant/MutantTest.php
+++ b/tests/phpunit/Mutant/MutantTest.php
@@ -62,7 +62,7 @@ final class MutantTest extends TestCase
             mutation: $mutation,
             mutatedCode: now($mutatedCode),
             diff: now($diff),
-            prettyPrintedOriginalCode: now($originalCode),
+            prettyPrintedOriginalCode: $originalCode,
         );
 
         $this->assertMutantStateIs(

--- a/tests/phpunit/Reporter/CreateMetricsCalculator.php
+++ b/tests/phpunit/Reporter/CreateMetricsCalculator.php
@@ -209,7 +209,7 @@ trait CreateMetricsCalculator
             20 - $i,
             10 - $i,
             20 - $i,
-            now('<?php $a = 1;'),
+            '<?php $a = 1;',
             now('<?php $a = 2;'),
             [],
             0.0,

--- a/tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php
+++ b/tests/phpunit/Reporter/Html/StrykerHtmlReportBuilderTest.php
@@ -480,7 +480,7 @@ final class StrykerHtmlReportBuilderTest extends TestCase
             $originalEndingLine,
             $originalStartFilePosition,
             $originalEndFilePosition,
-            now('<?php $a = 1;'),
+            '<?php $a = 1;',
             now('<?php $a = 2;'),
             $testLocations,
             0.0,


### PR DESCRIPTION
Follow up of the discussion from https://github.com/infection/infection/pull/3506#discussion_r3864598289. There is no reason to keep `Deferred<string>` over `string` anymore.