### PR TITLE
fix(git): Fix GitDiffSourceLineMatcher compatibility with Windows

### DIFF
--- a/src/Source/Matcher/GitDiffSourceLineMatcher.php
+++ b/src/Source/Matcher/GitDiffSourceLineMatcher.php
@@ -36,8 +36,10 @@ declare(strict_types=1);
 namespace Infection\Source\Matcher;
 
 use Infection\Differ\ChangedLinesRange;
+use Infection\Framework\OperatingSystem;
 use Infection\Git\Git;
 use Infection\Source\Exception\NoSourceFound;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @internal
@@ -86,6 +88,10 @@ final class GitDiffSourceLineMatcher implements SourceLineMatcher
             $this->sourceDirectories,
             $this->workingDirectory,
         );
+
+        if (OperatingSystem::isWindows()) {
+            $fileRealPath = Path::normalize($fileRealPath);
+        }
 
         return $this->memoizedFilesChangedLinesMap[$fileRealPath] ?? [];
     }

--- a/tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php
+++ b/tests/phpunit/Source/Matcher/GitDiffSourceLineMatcherTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Source\Matcher;
 
+use const DIRECTORY_SEPARATOR;
 use Infection\Differ\ChangedLinesRange;
 use Infection\Git\Git;
 use Infection\Source\Matcher\GitDiffSourceLineMatcher;
@@ -44,6 +45,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use function sprintf;
+use function str_replace;
 
 #[AllowMockObjectsWithoutExpectations]
 #[CoversClass(GitDiffSourceLineMatcher::class)]
@@ -144,6 +146,16 @@ final class GitDiffSourceLineMatcherTest extends TestCase
             '/path/to/src/File1.php',
             4,
             12,
+            true,
+        ];
+
+        yield 'the Windows real path is normalized before looking up changed lines' => [
+            [
+                'C:/path/to/src/File.php' => [ChangedLinesRange::forLine(3)],
+            ],
+            str_replace('/', DIRECTORY_SEPARATOR, 'C:/path/to/src/File.php'),
+            3,
+            3,
             true,
         ];
 


### PR DESCRIPTION
## Description

Since #3399, the paths returned by `Git::getChangedFilePaths()` have been absolute, so `GitDiffSourceLineMatcher` no longer needs to resolve them. Previously, `GitDiffSourceLineMatcher` used [`Filesystem::realpath()`](https://github.com/infection/infection/pull/3399/changes#diff-fff620a2b732d1185a52cab4447c54831ceaec8314672acfa56ee6b3ca48e9c7L104), which returns paths with native separators on Windows. By contrast, `Git::getChangedFilePaths()` [uses `Path::join()`](https://github.com/infection/infection/pull/3399/changes#diff-ac9ebefbc5789e378dc66a100cd4834967896ce96f73902d3ff656a0f1789171R247), which returns normalised paths with forward slashes.

On Windows, this mismatch prevents `GitDiffSourceLineMatcher` from matching any changed lines. `ExcludeUnchangedLinesVisitor` therefore marks every node as ineligible, and no mutations are generated.

## Changes

- Normalise the real file path in `GitDiffSourceLineMatcher` when running on Windows.

## Related issues

Fixes https://github.com/infection/infection/issues/3515.