### PR TITLE
Actualize PULL_REQUEST_TEMPLATE.md with new docs repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,9 @@
 ## Checklist
 
 - [ ] Tests added/updated
-- [ ] Documentation updated (provide link to PR: https://github.com/infection/site/pull/XXX)
+- [ ] Documentation updated (provide link to PR: https://github.com/infection/infection.github.io/pull/XXX)
 - [ ] CHANGELOG.md updated (if deprecations/breaking changes)
 - [ ] Appropriate labels applied (e.g. `performance`, `feature`).
-
 
 ## Breaking Changes
 
@@ -25,16 +24,6 @@
 
 ## Related issues
 
+<!-- Remove if not relevant -->
+
 Fixes https://github.com/infection/infection/issues/XXX.
-
-This PR:
-
-- [ ] Adds new feature ...
-- [ ] Covered by tests
-- [ ] Doc PR: https://github.com/infection/site/pull/XXX
-
-<!--
-Remove if not relevant
--->
-
-Fixes https://github.com/infection/infection/issues/XXX


### PR DESCRIPTION
We have a new site engine for https://infection.github.io/ using https://vitepress.dev/

https://github.com/infection/site has been archived.

Now the source files are in the https://github.com/infection/infection.github.io.

- PRs for docs should be done there
- PRs has builds checking the correctness of the site
- once merged to `main`, it autodeploys to https://infection.github.io/ 

This PR 

- updates the link in PR template
- removes duplicate information from PR template (seems like a leftover of previous changes)