### PR TITLE
ci: Make mago fail with the baseline is out of sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ phpstan-baseline: vendor $(PHPSTAN)
 
 .PHONY: mago
 mago: vendor $(MAGO)
-	$(MAGO) analyze
+	$(MAGO) analyze --fail-on-out-of-sync-baseline
 
 .PHONY: mago-baseline
 mago-baseline:		## Regenerates the Mago baseline


### PR DESCRIPTION
This prevents issues like #3520.