### PR TITLE
feat(test-framework): Route test framework operations through the new contract

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -211,24 +211,6 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 1
 
 [[issues]]
-file = "src/Command/InitialTest/InitialTestRunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/InitialTestRunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/InitialTestRunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
 file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `Infection\Command\InitialTest\Option\InitialTestsPhpOptionsOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''
@@ -448,6 +430,12 @@ count = 1
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\RunCommand::startUp`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\TestFramework\Contracts\Throwable\RequirementChecksFailed` in `Infection\Command\RunCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -975,205 +963,193 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:292:47}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:290:47}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:300:31}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:298:31}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:315:49}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:313:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:326:37}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:324:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:333:45}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:331:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:336:50}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:334:50}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:339:51}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:337:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:347:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:345:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:364:39}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:362:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:379:42}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:366:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:383:37}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:376:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:393:42}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:379:46}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:396:46}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:398:76}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:415:76}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:407:58}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:424:58}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:418:67}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:435:67}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:430:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:447:55}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:442:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:459:51}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:449:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:466:44}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:454:43}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:471:43}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:470:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:487:32}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:505:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:522:55}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:516:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:533:44}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:526:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:541:49}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:534:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:551:45}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:551:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:559:53}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:561:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:578:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:585:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:588:45}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:600:17}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:612:41}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:613:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:627:17}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:617:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:640:32}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:639:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:644:53}`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:666:37}`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:764:13}`.'
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `{closure:src/Container/Container.php:754:13}`.'
 count = 1
 
 [[issues]]
@@ -1185,205 +1161,193 @@ count = 1
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:292:47}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:290:47}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:300:31}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:298:31}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:315:49}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:313:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:326:37}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:324:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:333:45}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:331:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:336:50}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:334:50}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:339:51}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:337:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:347:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:345:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:364:39}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:362:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:379:42}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:366:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:383:37}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:376:42}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:393:42}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:379:46}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:396:46}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:398:76}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:415:76}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:407:58}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:424:58}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:418:67}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:435:67}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:430:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:447:55}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:442:51}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:459:51}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:449:44}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:466:44}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:454:43}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:471:43}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:470:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:487:32}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:505:55}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:522:55}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:516:49}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:533:44}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:526:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:541:49}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:534:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:551:45}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:551:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:559:53}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:561:45}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:578:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:585:41}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:588:45}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:600:17}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:612:41}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:613:32}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:627:17}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:617:53}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:640:32}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:639:37}`.'
 count = 1
 
 [[issues]]
 file = "src/Container/Container.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:644:53}`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:666:37}`.'
-count = 1
-
-[[issues]]
-file = "src/Container/Container.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:764:13}`.'
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `{closure:src/Container/Container.php:754:13}`.'
 count = 1
 
 [[issues]]
@@ -3955,6 +3919,24 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 2
 
 [[issues]]
+file = "tests/benchmark/ParseGitDiff/Generator.php"
+code = "impossible-condition"
+message = "This condition (type `false`) will always evaluate to false."
+count = 11
+
+[[issues]]
+file = "tests/benchmark/ParseGitDiff/Generator.php"
+code = "redundant-comparison"
+message = "Redundant `<=` comparison: left-hand side is never less than or equal to right-hand side."
+count = 8
+
+[[issues]]
+file = "tests/benchmark/ParseGitDiff/Generator.php"
+code = "redundant-comparison"
+message = "Redundant `===` comparison: left-hand side is never identical to right-hand side."
+count = 3
+
+[[issues]]
 file = "tests/benchmark/ParseGitDiff/GitParseDiffBench.php"
 code = "mixed-property-type-coercion"
 message = "A value with a less specific type `mixed` is being assigned to property `$count` (int)."
@@ -3965,24 +3947,6 @@ file = "tests/benchmark/ParseGitDiff/GitParseDiffBench.php"
 code = "mixed-property-type-coercion"
 message = "A value with a less specific type `mixed` is being assigned to property `$main` ((closure(...mixed=): mixed))."
 count = 1
-
-[[issues]]
-file = "tests/benchmark/ParseGitDiff/generator.php"
-code = "impossible-condition"
-message = "This condition (type `false`) will always evaluate to false."
-count = 11
-
-[[issues]]
-file = "tests/benchmark/ParseGitDiff/generator.php"
-code = "redundant-comparison"
-message = "Redundant `<=` comparison: left-hand side is never less than or equal to right-hand side."
-count = 8
-
-[[issues]]
-file = "tests/benchmark/ParseGitDiff/generator.php"
-code = "redundant-comparison"
-message = "Redundant `===` comparison: left-hand side is never identical to right-hand side."
-count = 3
 
 [[issues]]
 file = "tests/benchmark/ParseGitDiff/profile.php"

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -211,6 +211,12 @@ message = "Assigning `mixed` type to a variable may lead to unexpected behavior.
 count = 1
 
 [[issues]]
+file = "src/Command/InitialTest/InitialTestRunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\TestFramework\Contracts\Throwable\InitialTestsFailed` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
 file = "src/Command/InitialTest/Option/InitialTestsPhpOptionsOption.php"
 code = "invalid-return-statement"
 message = '''Invalid return type for function `Infection\Command\InitialTest\Option\InitialTestsPhpOptionsOption::addOption`: expected `('T.infection\command\option\commandoption::addoption() extends Symfony\Component\Console\Command\Command)`, but found `$this(Symfony\Component\Console\Command\Command)`.'''

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -763,12 +763,6 @@ parameters:
 			path: ../src/TestFramework/Contracts/TestFramework.php
 
 		-
-			rawMessage: Unused Infection\TestFramework\Contracts\TestFramework::getVersion
-			identifier: shipmonk.deadMethod
-			count: 1
-			path: ../src/TestFramework/Contracts/TestFramework.php
-
-		-
 			rawMessage: Function ini_get is unsafe to use. It can return FALSE instead of throwing an exception. Please add 'use function Safe\ini_get;' at the beginning of the file to use the variant provided by the 'thecodingmachine/safe' library.
 			identifier: theCodingMachineSafe.function
 			count: 1

--- a/src/Command/InitialTest/InitialTestRunCommand.php
+++ b/src/Command/InitialTest/InitialTestRunCommand.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Command\InitialTest;
 
-use function explode;
 use Infection\Command\BaseCommand;
 use Infection\Command\Git\Option\BaseOption;
 use Infection\Command\Git\Option\FilterOption;
@@ -44,11 +43,10 @@ use Infection\Command\Option\ConfigurationOption;
 use Infection\Command\Option\DebugOption;
 use Infection\Command\Option\TestFrameworkExtraArgsOption;
 use Infection\Command\Option\TestFrameworkOption;
-use Infection\Configuration\Configuration;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Console\IO;
 use Infection\Logger\Console\ConsoleLogger;
-use Infection\Process\Runner\InitialTestsFailed;
+use Infection\TestFramework\Contracts\Throwable\InitialTestsFailed;
 
 /**
  * @internal
@@ -75,6 +73,9 @@ final class InitialTestRunCommand extends BaseCommand
         DebugOption::addOption($this, default: true);
     }
 
+    /**
+     * @throws InitialTestsFailed
+     */
     protected function executeCommand(IO $io): bool
     {
         $logger = new ConsoleLogger($io);
@@ -95,52 +96,11 @@ final class InitialTestRunCommand extends BaseCommand
 
         $container->getSubscriberRegisterer()->registerSubscribers();
 
-        $configuration = $container->getConfiguration();
-        $initialTestsPhpOptions = self::getInitialTestsPhpOptions($configuration);
-
-        $initialTestSuiteInnerProcess = $container
-            ->getInitialTestsRunProcessFactory()
-            ->createProcess(
-                $configuration->testFrameworkExtraOptions,
-                $initialTestsPhpOptions,
-                $configuration->skipCoverage,
-            );
-
-        $io->writeln([
-            'Command executed:',
-            $initialTestSuiteInnerProcess->getCommandLine(),
-        ]);
-
-        $initialTestSuiteProcess = $container
-            ->getInitialTestsRunner()
-            ->run(
-                $configuration->testFrameworkExtraOptions,
-                $initialTestsPhpOptions,
-                $configuration->skipCoverage,
-            );
-
-        if (!$initialTestSuiteProcess->isSuccessful()) {
-            throw InitialTestsFailed::fromProcessAndAdapter(
-                $initialTestSuiteProcess,
-                $container->getTestFrameworkAdapter(),
-            );
-        }
+        $container->getTestFramework()->executeInitialRun();
 
         $io->newLine();
         $io->success('Initial test run successfully executed.');
 
         return true;
-    }
-
-    /**
-     * @return string[]
-     */
-    private static function getInitialTestsPhpOptions(Configuration $configuration): array
-    {
-        // Copied from Engine::getInitialTestsPhpOptionsArray
-        // The implementation looks a bit weird (will return [''] for an empty string),
-        // and the engine may not be the place where this should be done either...
-        // But to address at a later stage.
-        return explode(' ', (string) $configuration->initialTestsPhpOptions);
     }
 }

--- a/src/Command/InitialTest/InitialTestRunCommand.php
+++ b/src/Command/InitialTest/InitialTestRunCommand.php
@@ -46,7 +46,6 @@ use Infection\Command\Option\TestFrameworkOption;
 use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Console\IO;
 use Infection\Logger\Console\ConsoleLogger;
-use Infection\TestFramework\Contracts\Throwable\InitialTestsFailed;
 
 /**
  * @internal
@@ -73,9 +72,6 @@ final class InitialTestRunCommand extends BaseCommand
         DebugOption::addOption($this, default: true);
     }
 
-    /**
-     * @throws InitialTestsFailed
-     */
     protected function executeCommand(IO $io): bool
     {
         $logger = new ConsoleLogger($io);

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -66,6 +66,7 @@ use Infection\Resource\Processor\CpuCoresCountProvider;
 use Infection\Source\Exception\NoSourceFound;
 use Infection\StaticAnalysis\StaticAnalysisToolTypes;
 use Infection\TestFramework\AdapterInstaller;
+use Infection\TestFramework\Contracts\Throwable\RequirementChecksFailed;
 use Infection\TestFramework\TestFrameworkTypes;
 use InvalidArgumentException;
 use const PHP_SAPI;
@@ -540,6 +541,7 @@ final class RunCommand extends BaseCommand
      *
      * @throws ProcessTimedOutException
      * @throws ProcessException
+     * @throws RequirementChecksFailed
      */
     private function startUp(
         Container $container,
@@ -577,7 +579,7 @@ final class RunCommand extends BaseCommand
             $consoleOutput->logNotInControlOfExitCodes();
         }
 
-        $container->getCoverageChecker()->checkCoverageRequirements();
+        $container->getTestFramework()->checkRequirements();
 
         $config = $container->getConfiguration();
 

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -426,7 +426,7 @@ final class Container extends DIContainer
 
                 return new InitialTestsExecutionLoggerFactory(
                     $config->noProgress,
-                    $container->getTestFrameworkAdapter(),
+                    $container->getTestFramework(),
                     $config->isDebugEnabled,
                     $container->getOutput(),
                 );

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -39,7 +39,6 @@ use function array_filter;
 use Closure;
 use DIContainer\Container as DIContainer;
 use function dirname;
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\CI\MemoizedCiDetector;
 use Infection\CI\NullCiDetector;
 use Infection\Configuration\Configuration;
@@ -111,7 +110,6 @@ use Infection\Metrics\ResultsCollector;
 use Infection\Metrics\TargetDetectionStatusesProvider;
 use Infection\Mutant\MutantCodeFactory;
 use Infection\Mutant\MutantFactory;
-use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Mutation\FileMutationGenerator;
 use Infection\Mutation\MutationGenerator;
 use Infection\Mutator\MutatorFactory;
@@ -361,21 +359,6 @@ final class Container extends DIContainer
                 [$container->getProjectDir()],
                 $container->getFileSystem(),
             ),
-            CoverageChecker::class => static function (self $container): CoverageChecker {
-                $config = $container->getConfiguration();
-                $testFrameworkAdapter = $container->getTestFrameworkAdapter();
-
-                return new CoverageChecker(
-                    $config->skipCoverage,
-                    $config->skipInitialTests,
-                    $config->initialTestsPhpOptions ?? '',
-                    $config->coveragePath,
-                    $testFrameworkAdapter->hasJUnitReport(),
-                    $container->getJUnitReportLocator(),
-                    $testFrameworkAdapter->getName(),
-                    $container->getIndexXmlCoverageLocator(),
-                );
-            },
             JUnitReportLocator::class => static fn (self $container) => JUnitReportLocator::create(
                 $container->getFileSystem(),
                 $container->getConfiguration()->coveragePath,
@@ -530,14 +513,6 @@ final class Container extends DIContainer
                     $config->timeoutsAsEscaped,
                 );
             },
-            TestFrameworkAdapter::class => static function (self $container): TestFrameworkAdapter {
-                $config = $container->getConfiguration();
-
-                return $container->getFactory()->create(
-                    $config->testFramework,
-                    $config->skipCoverage,
-                );
-            },
             StaticAnalysisToolAdapter::class => static function (self $container): StaticAnalysisToolAdapter {
                 $config = $container->getConfiguration();
 
@@ -568,9 +543,7 @@ final class Container extends DIContainer
                 $configuration = $container->getConfiguration();
 
                 return new MutantProcessContainerFactory(
-                    $container->getTestFrameworkAdapter(),
                     $configuration->processTimeout,
-                    $container->getMutantExecutionResultFactory(),
                     $mutantProcessKillerFactories,
                     $container->getConfiguration(),
                 );
@@ -663,15 +636,32 @@ final class Container extends DIContainer
                 ),
                 new CurrentWorkingDirectoryProvider(),
             ),
-            TestFramework::class => static fn (self $container) => new LegacyTestFrameworkBridge(
-                $container->getTestFrameworkAdapter(),
-                $container->get(ConsoleOutput::class),
-                $container->getCoverageChecker(),
-                $container->getInitialTestsRunner(),
-                $container->getConfiguration(),
-                $container->getMutantProcessContainerFactory(),
-                $container->getTestFrameworkExtraOptionsFilter(),
-            ),
+            TestFramework::class => static function (self $container): TestFramework {
+                $config = $container->getConfiguration();
+                $adapter = $container->getFactory()->create(
+                    $config->testFramework,
+                    $config->skipCoverage,
+                );
+
+                return new LegacyTestFrameworkBridge(
+                    $adapter,
+                    $container->get(ConsoleOutput::class),
+                    new CoverageChecker(
+                        $config->skipCoverage,
+                        $config->skipInitialTests,
+                        $config->initialTestsPhpOptions ?? '',
+                        $config->coveragePath,
+                        $adapter->hasJUnitReport(),
+                        $container->getJUnitReportLocator(),
+                        $adapter->getName(),
+                        $container->getIndexXmlCoverageLocator(),
+                    ),
+                    $container->getInitialTestsRunner(),
+                    $config,
+                    $container->getMutantProcessContainerFactory(),
+                    $container->getTestFrameworkExtraOptionsFilter(),
+                );
+            },
         ]);
 
         return $container->withValues(
@@ -930,11 +920,6 @@ final class Container extends DIContainer
         return $this->get(TestFramework::class);
     }
 
-    public function getTestFrameworkAdapter(): TestFrameworkAdapter
-    {
-        return $this->get(TestFrameworkAdapter::class);
-    }
-
     public function getStaticAnalysisToolAdapter(): StaticAnalysisToolAdapter
     {
         return $this->get(StaticAnalysisToolAdapter::class);
@@ -1040,11 +1025,6 @@ final class Container extends DIContainer
         return $this->get(AdapterInstaller::class);
     }
 
-    public function getMutantExecutionResultFactory(): TestFrameworkMutantExecutionResultFactory
-    {
-        return $this->get(TestFrameworkMutantExecutionResultFactory::class);
-    }
-
     public function getCiDetector(): CiDetector
     {
         return $this->get(CiDetector::class);
@@ -1103,11 +1083,6 @@ final class Container extends DIContainer
     public function getRootsFileOrDirectoryLocator(): RootsFileOrDirectoryLocator
     {
         return $this->get(RootsFileOrDirectoryLocator::class);
-    }
-
-    public function getCoverageChecker(): CoverageChecker
-    {
-        return $this->get(CoverageChecker::class);
     }
 
     public function getEventDispatcher(): EventDispatcher

--- a/src/Logger/ArtefactCollection/ConsoleNoProgressLogger.php
+++ b/src/Logger/ArtefactCollection/ConsoleNoProgressLogger.php
@@ -35,10 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Logger\ArtefactCollection;
 
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLogger;
 use Infection\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLogger;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
+use Infection\TestFramework\Contracts\TestFramework;
 use InvalidArgumentException;
 use function sprintf;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -49,7 +49,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 final readonly class ConsoleNoProgressLogger implements InitialStaticAnalysisExecutionLogger, InitialTestsExecutionLogger
 {
     public function __construct(
-        private TestFrameworkAdapter|StaticAnalysisToolAdapter $testFramework,
+        private TestFramework|StaticAnalysisToolAdapter $testFramework,
         private OutputInterface $output,
     ) {
     }

--- a/src/Logger/ArtefactCollection/ConsoleProgressBarLogger.php
+++ b/src/Logger/ArtefactCollection/ConsoleProgressBarLogger.php
@@ -35,10 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Logger\ArtefactCollection;
 
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Logger\ArtefactCollection\InitialStaticAnalysisExecution\InitialStaticAnalysisExecutionLogger;
 use Infection\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLogger;
 use Infection\StaticAnalysis\StaticAnalysisToolAdapter;
+use Infection\TestFramework\Contracts\TestFramework;
 use InvalidArgumentException;
 use function sprintf;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -53,7 +53,7 @@ final readonly class ConsoleProgressBarLogger implements InitialStaticAnalysisEx
 
     public function __construct(
         private OutputInterface $output,
-        private TestFrameworkAdapter|StaticAnalysisToolAdapter $testFramework,
+        private TestFramework|StaticAnalysisToolAdapter $testFramework,
         private bool $debug,
     ) {
         $this->progressBar = new ProgressBar($this->output);

--- a/src/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactory.php
+++ b/src/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactory.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Logger\ArtefactCollection\InitialTestsExecution;
 
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Logger\ArtefactCollection\ConsoleNoProgressLogger;
 use Infection\Logger\ArtefactCollection\ConsoleProgressBarLogger;
+use Infection\TestFramework\Contracts\TestFramework;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -47,7 +47,7 @@ final readonly class InitialTestsExecutionLoggerFactory
 {
     public function __construct(
         private bool $skipProgressBar,
-        private TestFrameworkAdapter $testFrameworkAdapter,
+        private TestFramework $testFramework,
         private bool $debug,
         private OutputInterface $output,
     ) {
@@ -57,12 +57,12 @@ final readonly class InitialTestsExecutionLoggerFactory
     {
         return $this->skipProgressBar
             ? new ConsoleNoProgressLogger(
-                $this->testFrameworkAdapter,
+                $this->testFramework,
                 $this->output,
             )
             : new ConsoleProgressBarLogger(
                 $this->output,
-                $this->testFrameworkAdapter,
+                $this->testFramework,
                 $this->debug,
             )
         ;

--- a/src/Process/Factory/InitialTestsRunProcessFactory.php
+++ b/src/Process/Factory/InitialTestsRunProcessFactory.php
@@ -46,17 +46,13 @@ use Symfony\Component\Process\Process;
  */
 class InitialTestsRunProcessFactory
 {
-    public function __construct(
-        private readonly TestFrameworkAdapter $testFrameworkAdapter,
-    ) {
-    }
-
     /**
      * Creates process with enabled debugger as test framework is going to use in the code coverage.
      *
      * @param string[] $phpExtraOptions
      */
     public function createProcess(
+        TestFrameworkAdapter $testFrameworkAdapter,
         string $testFrameworkExtraOptions,
         array $phpExtraOptions,
         bool $skipCoverage,
@@ -65,7 +61,7 @@ class InitialTestsRunProcessFactory
         $processClass = $skipCoverage ? Process::class : OriginalPhpProcess::class;
 
         return new $processClass(
-            command: $this->testFrameworkAdapter->getInitialTestRunCommandLine(
+            command: $testFrameworkAdapter->getInitialTestRunCommandLine(
                 $testFrameworkExtraOptions,
                 $phpExtraOptions,
                 $skipCoverage,

--- a/src/Process/Factory/MutantProcessContainerFactory.php
+++ b/src/Process/Factory/MutantProcessContainerFactory.php
@@ -38,7 +38,7 @@ namespace Infection\Process\Factory;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Configuration\Configuration;
 use Infection\Mutant\Mutant;
-use Infection\Mutant\MutantExecutionResultFactory;
+use Infection\Mutant\TestFrameworkMutantExecutionResultFactory;
 use Infection\Process\DryRunProcess;
 use Infection\Process\MutantProcess;
 use Infection\Process\MutantProcessContainer;
@@ -57,9 +57,7 @@ class MutantProcessContainerFactory
     private const int TEST_FRAMEWORK_BOOTSTRAP_THRESHOLD = 5;
 
     public function __construct(
-        private readonly TestFrameworkAdapter $testFrameworkAdapter,
         private readonly float $timeout,
-        private readonly MutantExecutionResultFactory $mutantExecutionResultFactory,
         /**
          * @var list<LazyMutantProcessFactory>
          */
@@ -68,13 +66,16 @@ class MutantProcessContainerFactory
     ) {
     }
 
-    public function create(Mutant $mutant, string $testFrameworkExtraOptions = ''): MutantProcessContainer
-    {
+    public function create(
+        TestFrameworkAdapter $testFrameworkAdapter,
+        Mutant $mutant,
+        string $testFrameworkExtraOptions = '',
+    ): MutantProcessContainer {
         // getNominalTestExecutionTime() returns the time the test-suite requires to run the test, excluding process creation and test-framework bootstrapping.
         $timeout = min(self::TEST_FRAMEWORK_BOOTSTRAP_THRESHOLD + (self::TIMEOUT_FACTOR * $mutant->getMutation()->getNominalTestExecutionTime()), $this->timeout);
 
         $process = new Process(
-            command: $this->testFrameworkAdapter->getMutantCommandLine(
+            command: $testFrameworkAdapter->getMutantCommandLine(
                 $mutant->getTests(),
                 $mutant->getFilePath(),
                 $mutant->getMutation()->getHash(),
@@ -93,7 +94,7 @@ class MutantProcessContainerFactory
             new MutantProcess(
                 $process,
                 $mutant,
-                $this->mutantExecutionResultFactory,
+                new TestFrameworkMutantExecutionResultFactory($testFrameworkAdapter),
             ),
             $this->lazyMutantProcessCreators,
         );

--- a/src/Process/Runner/InitialTestsRunner.php
+++ b/src/Process/Runner/InitialTestsRunner.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Process\Runner;
 
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Event\EventDispatcher\EventDispatcher;
 use Infection\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestCaseWasCompleted;
 use Infection\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestSuiteWasFinished;
@@ -58,11 +59,13 @@ class InitialTestsRunner
      * @param string[] $phpExtraOptions
      */
     public function run(
+        TestFrameworkAdapter $testFrameworkAdapter,
         string $testFrameworkExtraOptions,
         array $phpExtraOptions,
         bool $skipCoverage,
     ): Process {
         $process = $this->processBuilder->createProcess(
+            $testFrameworkAdapter,
             $testFrameworkExtraOptions,
             $phpExtraOptions,
             $skipCoverage,

--- a/src/TestFramework/Contracts/TestFramework.php
+++ b/src/TestFramework/Contracts/TestFramework.php
@@ -89,8 +89,5 @@ interface TestFramework
      */
     public function test(Mutant $mutant): MutantProcessContainer;
 
-    /**
-     * @deprecated Should be removed as soon as it is unused.
-     */
     public function hasJUnitReport(): bool;
 }

--- a/src/TestFramework/Contracts/TestFramework.php
+++ b/src/TestFramework/Contracts/TestFramework.php
@@ -88,4 +88,9 @@ interface TestFramework
      * is interpreted.
      */
     public function test(Mutant $mutant): MutantProcessContainer;
+
+    /**
+     * @deprecated Should be removed as soon as it is unused.
+     */
+    public function hasJUnitReport(): bool;
 }

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage\JUnit;
 
+use Infection\TestFramework\Contracts\TestFramework;
 use function explode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
@@ -54,7 +55,7 @@ class JUnitTestExecutionInfoAdder
     private const int MAX_EXPLODE_PARTS = 2;
 
     public function __construct(
-        private readonly TestFrameworkAdapter $adapter,
+        private readonly TestFramework        $testFramework,
         private readonly TestFileDataProvider $testFileDataProvider,
     ) {
     }
@@ -68,7 +69,7 @@ class JUnitTestExecutionInfoAdder
      */
     public function addTestExecutionInfo(iterable $traces): iterable
     {
-        if (!$this->adapter->hasJUnitReport()) {
+        if (!$this->testFramework->hasJUnitReport()) {
             return $traces;
         }
 

--- a/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+++ b/src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
@@ -35,10 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Coverage\JUnit;
 
-use Infection\TestFramework\Contracts\TestFramework;
 use function explode;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\TestFramework\Contracts\TestFramework;
 use Infection\TestFramework\Tracing\Trace\ProxyTrace;
 use Infection\TestFramework\Tracing\Trace\TestLocations;
 use Infection\TestFramework\Tracing\Trace\Trace;
@@ -55,7 +54,7 @@ class JUnitTestExecutionInfoAdder
     private const int MAX_EXPLODE_PARTS = 2;
 
     public function __construct(
-        private readonly TestFramework        $testFramework,
+        private readonly TestFramework $testFramework,
         private readonly TestFileDataProvider $testFileDataProvider,
     ) {
     }

--- a/src/TestFramework/LegacyTestFrameworkBridge.php
+++ b/src/TestFramework/LegacyTestFrameworkBridge.php
@@ -146,4 +146,9 @@ final readonly class LegacyTestFrameworkBridge implements TestFramework
 
         return $this->config->testFrameworkExtraOptions;
     }
+
+    public function hasJUnitReport(): bool
+    {
+        return $this->adapter->hasJUnitReport();
+    }
 }

--- a/src/TestFramework/LegacyTestFrameworkBridge.php
+++ b/src/TestFramework/LegacyTestFrameworkBridge.php
@@ -81,6 +81,8 @@ final readonly class LegacyTestFrameworkBridge implements TestFramework
     {
         // TODO: check supported version
 
+        $this->coverageChecker->checkCoverageRequirements();
+
         if ($this->config->skipInitialTests) {
             $this->consoleOutput->logSkippingInitialTests();
             $this->coverageChecker->checkCoverageExists();
@@ -90,6 +92,7 @@ final readonly class LegacyTestFrameworkBridge implements TestFramework
     public function executeInitialRun(): InitialRunResults
     {
         $initialTestSuiteProcess = $this->initialTestsRunner->run(
+            $this->adapter,
             $this->config->testFrameworkExtraOptions,
             $this->getInitialTestsPhpOptionsArray(),
             $this->config->skipCoverage,
@@ -122,9 +125,15 @@ final readonly class LegacyTestFrameworkBridge implements TestFramework
     public function test(Mutant $mutant): MutantProcessContainer
     {
         return $this->processFactory->create(
+            $this->adapter,
             $mutant,
             $this->getFilteredExtraOptionsForMutant(),
         );
+    }
+
+    public function hasJUnitReport(): bool
+    {
+        return $this->adapter->hasJUnitReport();
     }
 
     /**
@@ -145,10 +154,5 @@ final readonly class LegacyTestFrameworkBridge implements TestFramework
         }
 
         return $this->config->testFrameworkExtraOptions;
-    }
-
-    public function hasJUnitReport(): bool
-    {
-        return $this->adapter->hasJUnitReport();
     }
 }

--- a/tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php
+++ b/tests/phpunit/Command/InitialTest/InitialTestRunCommandTest.php
@@ -35,14 +35,14 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Command\InitialTest;
 
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Command\InitialTest\InitialTestRunCommand;
 use Infection\Console\Application;
 use Infection\Container\Container;
 use Infection\Framework\Str;
 use Infection\Git\Git;
 use Infection\Process\Runner\InitialTestsFailed;
-use Infection\Process\Runner\InitialTestsRunner;
+use Infection\TestFramework\Contracts\InitialRunResults;
+use Infection\TestFramework\Contracts\TestFramework;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -52,7 +52,6 @@ use function Safe\chdir;
 use function Safe\getcwd;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Process\Process;
 
 #[AllowMockObjectsWithoutExpectations]
 #[Group('integration')]
@@ -76,25 +75,15 @@ final class InitialTestRunCommandTest extends TestCase
 
     /**
      * @param array<string, string> $arguments
-     * @param string[] $expectedInitialTestsPhpOptions
      */
     #[DataProvider('successfulCommandExecutionProvider')]
     public function test_it_executes_the_initial_tests(
         array $arguments,
-        bool $successfulInitialTests,
-        string $expectedTestFrameworkExtraOptions,
-        array $expectedInitialTestsPhpOptions,
-        bool $expectedSkipCoverage,
         string $expectedStdout,
         string $expectedStderr,
         string $expectedDisplay,
     ): void {
-        $tester = $this->createCommandTester(
-            $successfulInitialTests,
-            $expectedTestFrameworkExtraOptions,
-            $expectedInitialTestsPhpOptions,
-            $expectedSkipCoverage,
-        );
+        $tester = $this->createCommandTester();
 
         [
             $actualStdout,
@@ -111,12 +100,7 @@ final class InitialTestRunCommandTest extends TestCase
     {
         yield 'default parameters with successful tests' => [
             'arguments' => [],
-            'successfulInitialTests' => true,
-            'expectedTestFrameworkExtraOptions' => '',
-            'expectedInitialTestsPhpOptions' => [''],
-            'expectedSkipCoverage' => false,
             'expectedStdout' => <<<STDOUT
-                Command executed:
 
 
                  [OK] Initial test run successfully executed.
@@ -127,7 +111,6 @@ final class InitialTestRunCommandTest extends TestCase
 
                 STDERR,
             'expectedDisplay' => <<<DISPLAY
-                Command executed:
 
 
                  [OK] Initial test run successfully executed.
@@ -139,23 +122,13 @@ final class InitialTestRunCommandTest extends TestCase
 
     /**
      * @param array<string, string> $arguments
-     * @param string[] $expectedInitialTestsPhpOptions
      */
     #[DataProvider('failingCommandExecutionProvider')]
     public function test_it_executes_the_initial_tests_with_failing_tests(
         array $arguments,
-        bool $successfulInitialTests,
-        string $expectedTestFrameworkExtraOptions,
-        array $expectedInitialTestsPhpOptions,
-        bool $expectedSkipCoverage,
         InitialTestsFailed $expected,
     ): void {
-        $tester = $this->createCommandTester(
-            $successfulInitialTests,
-            $expectedTestFrameworkExtraOptions,
-            $expectedInitialTestsPhpOptions,
-            $expectedSkipCoverage,
-        );
+        $tester = $this->createCommandTester($expected);
 
         $this->expectExceptionObject($expected);
 
@@ -172,10 +145,6 @@ final class InitialTestRunCommandTest extends TestCase
     {
         yield 'default parameters with failing tests' => [
             'arguments' => [],
-            'successfulInitialTests' => false,
-            'expectedTestFrameworkExtraOptions' => '',
-            'expectedInitialTestsPhpOptions' => [''],
-            'expectedSkipCoverage' => false,
             'expected' => new InitialTestsFailed(
                 <<<'MESSAGE'
                     Project tests must be in a passing state before running Infection.
@@ -191,56 +160,27 @@ final class InitialTestRunCommandTest extends TestCase
         ];
     }
 
-    /**
-     * @param string[] $expectedInitialTestsPhpOptions
-     */
-    private function createCommandTester(
-        bool $successfulInitialTests,
-        string $expectedTestFrameworkExtraOptions,
-        array $expectedInitialTestsPhpOptions,
-        bool $expectedSkipCoverage,
-    ): CommandTester {
+    private function createCommandTester(?InitialTestsFailed $failure = null): CommandTester
+    {
         $gitMock = $this->createMock(Git::class);
         $gitMock
             ->method('getBaseReference')
             ->willReturn('<refinedGitReference>');
 
-        $testFrameworkAdapterMock = $this->createMock(TestFrameworkAdapter::class);
-        $testFrameworkAdapterMock
-            ->method('getName')
-            ->willReturn('DemoTestFramework');
+        $testFrameworkMock = $this->createMock(TestFramework::class);
+        $executeInitialRunExpectation = $testFrameworkMock
+            ->expects($failure === null ? $this->exactly(2) : $this->once())
+            ->method('executeInitialRun');
 
-        $initialTestsProcessMock = $this->createMock(Process::class);
-        $initialTestsProcessMock
-            ->method('getCommandLine')
-            ->willReturn('test-framework initialConfig');
-        $initialTestsProcessMock
-            ->method('isSuccessful')
-            ->willReturn($successfulInitialTests);
-        $initialTestsProcessMock
-            ->method('getExitCode')
-            ->willReturn(123);
-        $initialTestsProcessMock
-            ->method('getOutput')
-            ->willReturn('<processOutput>');
-        $initialTestsProcessMock
-            ->method('getErrorOutput')
-            ->willReturn('<processErrorOutput>');
-
-        $initialTestsRunnerMock = $this->createMock(InitialTestsRunner::class);
-        $initialTestsRunnerMock
-            ->method('run')
-            ->with(
-                $expectedTestFrameworkExtraOptions,
-                $expectedInitialTestsPhpOptions,
-                $expectedSkipCoverage,
-            )
-            ->willReturn($initialTestsProcessMock);
+        if ($failure !== null) {
+            $executeInitialRunExpectation->willThrowException($failure);
+        } else {
+            $executeInitialRunExpectation->willReturn(new InitialRunResults('', null));
+        }
 
         $container = Container::create()
             ->cloneWithService(Git::class, $gitMock)
-            ->cloneWithService(TestFrameworkAdapter::class, $testFrameworkAdapterMock)
-            ->cloneWithService(InitialTestsRunner::class, $initialTestsRunnerMock);
+            ->cloneWithService(TestFramework::class, $testFrameworkMock);
 
         $application = new Application($container);
 

--- a/tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php
+++ b/tests/phpunit/Logger/ArtefactCollection/ConsoleNoProgressLoggerTest.php
@@ -38,7 +38,7 @@ namespace Infection\Tests\Logger\ArtefactCollection;
 use Infection\Framework\Str;
 use Infection\Logger\ArtefactCollection\ConsoleNoProgressLogger;
 use Infection\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLogger;
-use Infection\TestFramework\AbstractTestFrameworkAdapter;
+use Infection\TestFramework\Contracts\TestFramework;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -49,14 +49,14 @@ final class ConsoleNoProgressLoggerTest extends TestCase
 {
     private BufferedOutput $output;
 
-    private MockObject&AbstractTestFrameworkAdapter $testFrameworkMock;
+    private MockObject&TestFramework $testFrameworkMock;
 
     private InitialTestsExecutionLogger $logger;
 
     protected function setUp(): void
     {
         $this->output = new BufferedOutput();
-        $this->testFrameworkMock = $this->createMock(AbstractTestFrameworkAdapter::class);
+        $this->testFrameworkMock = $this->createMock(TestFramework::class);
 
         $this->logger = new ConsoleNoProgressLogger(
             $this->testFrameworkMock,

--- a/tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php
+++ b/tests/phpunit/Logger/ArtefactCollection/ConsoleProgressBarLoggerTest.php
@@ -35,9 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger\ArtefactCollection;
 
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Logger\ArtefactCollection\ConsoleProgressBarLogger;
 use Infection\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLogger;
+use Infection\TestFramework\Contracts\TestFramework;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -51,12 +51,12 @@ final class ConsoleProgressBarLoggerTest extends TestCase
 {
     private OutputInterface&MockObject $outputMock;
 
-    private TestFrameworkAdapter&MockObject $testFrameworkMock;
+    private TestFramework&MockObject $testFrameworkMock;
 
     protected function setUp(): void
     {
         $this->outputMock = $this->createMock(OutputInterface::class);
-        $this->testFrameworkMock = $this->createMock(TestFrameworkAdapter::class);
+        $this->testFrameworkMock = $this->createMock(TestFramework::class);
     }
 
     public function test_it_logs_the_start(): void

--- a/tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php
+++ b/tests/phpunit/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactoryTest.php
@@ -35,10 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Logger\ArtefactCollection\InitialTestsExecution;
 
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Logger\ArtefactCollection\ConsoleNoProgressLogger;
 use Infection\Logger\ArtefactCollection\ConsoleProgressBarLogger;
 use Infection\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactory;
+use Infection\TestFramework\Contracts\TestFramework;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -50,14 +50,14 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[CoversClass(InitialTestsExecutionLoggerFactory::class)]
 final class InitialTestsExecutionLoggerFactoryTest extends TestCase
 {
-    private TestFrameworkAdapter&MockObject $testFrameworkAdapterMock;
+    private TestFramework&MockObject $testFrameworkMock;
 
     private OutputInterface&MockObject $outputMock;
 
     protected function setUp(): void
     {
-        $this->testFrameworkAdapterMock = $this->createMock(TestFrameworkAdapter::class);
-        $this->testFrameworkAdapterMock
+        $this->testFrameworkMock = $this->createMock(TestFramework::class);
+        $this->testFrameworkMock
             ->expects($this->never())
             ->method($this->anything());
 
@@ -108,7 +108,7 @@ final class InitialTestsExecutionLoggerFactoryTest extends TestCase
     ): InitialTestsExecutionLoggerFactory {
         return new InitialTestsExecutionLoggerFactory(
             $skipProgressBar,
-            $this->testFrameworkAdapterMock,
+            $this->testFrameworkMock,
             $debug,
             $this->outputMock,
         );

--- a/tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php
+++ b/tests/phpunit/Process/Factory/InitialTestsRunProcessFactoryTest.php
@@ -53,7 +53,7 @@ final class InitialTestsRunProcessFactoryTest extends TestCase
     {
         $this->testFrameworkAdapterMock = $this->createMock(TestFrameworkAdapter::class);
 
-        $this->factory = new InitialTestsRunProcessFactory($this->testFrameworkAdapterMock);
+        $this->factory = new InitialTestsRunProcessFactory();
     }
 
     public function test_it_creates_a_process_with_coverage_skipped(): void
@@ -68,6 +68,7 @@ final class InitialTestsRunProcessFactoryTest extends TestCase
         ;
 
         $process = $this->factory->createProcess(
+            $this->testFrameworkAdapterMock,
             $testFrameworkExtraOptions,
             $phpExtraOptions,
             true,
@@ -97,6 +98,7 @@ final class InitialTestsRunProcessFactoryTest extends TestCase
         ;
 
         $process = $this->factory->createProcess(
+            $this->testFrameworkAdapterMock,
             $testFrameworkExtraOptions,
             $phpExtraOptions,
             false,

--- a/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
+++ b/tests/phpunit/Process/Factory/MutantProcessContainerFactoryTest.php
@@ -37,7 +37,6 @@ namespace Infection\Tests\Process\Factory;
 
 use Infection\AbstractTestFramework\Coverage\TestLocation;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
-use Infection\Mutant\MutantExecutionResultFactory;
 use Infection\Mutation\Mutation;
 use Infection\Mutator\Loop\For_;
 use Infection\PhpParser\MutatedNode;
@@ -46,7 +45,6 @@ use Infection\Testing\MutatorName;
 use Infection\Tests\Configuration\ConfigurationBuilder;
 use Infection\Tests\Fixtures\Event\EventDispatcherCollector;
 use Infection\Tests\Mutant\MutantBuilder;
-use Infection\Tests\Mutant\MutantExecutionResultBuilder;
 use PhpParser\Node\Stmt\Nop;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -118,27 +116,17 @@ final class MutantProcessContainerFactoryTest extends TestCase
 
         $eventDispatcher = new EventDispatcherCollector();
 
-        $executionResult = MutantExecutionResultBuilder::withMinimalTestData()->build();
-
-        $resultFactoryStub = $this->createStub(MutantExecutionResultFactory::class);
-        $resultFactoryStub
-            ->method('createFromProcess')
-            ->willReturn($executionResult)
-        ;
-
         $configuration = ConfigurationBuilder::withMinimalTestData()
             ->withDryRun(false)
             ->build();
 
         $factory = new MutantProcessContainerFactory(
-            $testFrameworkAdapterMock,
             $processFactoryTimeout,
-            $resultFactoryStub,
             [],
             $configuration,
         );
 
-        $mutantProcess = $factory->create($mutant, $testFrameworkExtraOptions);
+        $mutantProcess = $factory->create($testFrameworkAdapterMock, $mutant, $testFrameworkExtraOptions);
 
         $process = $mutantProcess->getCurrent()->getProcess();
 

--- a/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
+++ b/tests/phpunit/Process/Runner/InitialTestsRunnerTest.php
@@ -42,6 +42,7 @@ use function array_values;
 use function count;
 use function end;
 use function extension_loaded;
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestCaseWasCompleted;
 use Infection\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestSuiteWasFinished;
 use Infection\Event\Events\ArtefactCollection\InitialTestExecution\InitialTestSuiteWasStarted;
@@ -67,6 +68,8 @@ final class InitialTestsRunnerTest extends TestCase
 
     private InitialTestsRunner $runner;
 
+    private TestFrameworkAdapter $testFrameworkAdapter;
+
     protected function setUp(): void
     {
         if (PHP_SAPI === 'phpdbg') {
@@ -78,6 +81,7 @@ final class InitialTestsRunnerTest extends TestCase
         $this->eventDispatcher = new EventDispatcherCollector();
 
         $this->runner = new InitialTestsRunner($this->processFactoryMock, $this->eventDispatcher);
+        $this->testFrameworkAdapter = $this->createStub(TestFrameworkAdapter::class);
     }
 
     public function test_it_creates_a_process_execute_it_and_dispatch_events_accordingly(): void
@@ -94,11 +98,11 @@ final class InitialTestsRunnerTest extends TestCase
 
         $this->processFactoryMock
             ->method('createProcess')
-            ->with($testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage)
+            ->with($this->testFrameworkAdapter, $testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage)
             ->willReturn($process)
         ;
 
-        $this->runner->run($testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage);
+        $this->runner->run($this->testFrameworkAdapter, $testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage);
 
         $this->assertSame(
             [
@@ -129,12 +133,12 @@ final class InitialTestsRunnerTest extends TestCase
 
         $this->processFactoryMock
             ->method('createProcess')
-            ->with($testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage)
+            ->with($this->testFrameworkAdapter, $testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage)
             ->willReturn($process)
         ;
 
         try {
-            $this->runner->run($testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage);
+            $this->runner->run($this->testFrameworkAdapter, $testFrameworkExtraOptions, $phpExtraOptions, $skipCoverage);
         } catch (RuntimeException $e) {
             // Signal 11, AKA "segmentation fault", is not something we can do anything about
             if (extension_loaded('xdebug') && str_contains($e->getMessage(), 'The process has been signaled with signal "11"')) {

--- a/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
+++ b/tests/phpunit/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdderTest.php
@@ -37,7 +37,7 @@ namespace Infection\Tests\TestFramework\Coverage\JUnit;
 
 use Exception;
 use Infection\AbstractTestFramework\Coverage\TestLocation;
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\TestFramework\Contracts\TestFramework;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
 use Infection\TestFramework\Coverage\JUnit\TestFileDataProvider;
 use Infection\TestFramework\Coverage\JUnit\TestFileTimeData;
@@ -59,7 +59,7 @@ use SplFileInfo;
 #[CoversClass(JUnitTestExecutionInfoAdder::class)]
 final class JUnitTestExecutionInfoAdderTest extends TestCase
 {
-    private TestFrameworkAdapter&MockObject $testFrameworkAdapterMock;
+    private TestFramework&MockObject $testFrameworkMock;
 
     private TestFileDataProvider&MockObject $testFileDataProviderMock;
 
@@ -67,18 +67,18 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->testFrameworkAdapterMock = $this->createMock(TestFrameworkAdapter::class);
+        $this->testFrameworkMock = $this->createMock(TestFramework::class);
         $this->testFileDataProviderMock = $this->createMock(TestFileDataProvider::class);
 
         $this->infoAdder = new JUnitTestExecutionInfoAdder(
-            $this->testFrameworkAdapterMock,
+            $this->testFrameworkMock,
             $this->testFileDataProviderMock,
         );
     }
 
     public function test_it_does_not_add_if_junit_is_not_provided(): void
     {
-        $this->testFrameworkAdapterMock
+        $this->testFrameworkMock
             ->expects($this->once())
             ->method('hasJUnitReport')
             ->willReturn(false)
@@ -94,7 +94,7 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
 
     public function test_it_adds_if_junit_is_provided(): void
     {
-        $this->testFrameworkAdapterMock
+        $this->testFrameworkMock
             ->expects($this->once())
             ->method('hasJUnitReport')
             ->willReturn(true)
@@ -158,7 +158,7 @@ final class JUnitTestExecutionInfoAdderTest extends TestCase
 
     public function test_it_does_not_load_the_trace_tests_until_necessary(): void
     {
-        $this->testFrameworkAdapterMock
+        $this->testFrameworkMock
             ->expects($this->once())
             ->method('hasJUnitReport')
             ->willReturn(true)

--- a/tests/phpunit/TestFramework/LegacyTestFrameworkBridgeTest.php
+++ b/tests/phpunit/TestFramework/LegacyTestFrameworkBridgeTest.php
@@ -125,12 +125,13 @@ final class LegacyTestFrameworkBridgeTest extends TestCase
     public function test_it_executes_initial_run_and_reports_memory_usage(): void
     {
         $process = $this->createSuccessfulInitialRunProcess('output');
+        $adapter = new FakeAwareAdapter(42.0);
 
         $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
         $initialTestsRunner
             ->expects($this->once())
             ->method('run')
-            ->with('', [''], false)
+            ->with($adapter, '', [''], false)
             ->willReturn($process)
         ;
 
@@ -142,7 +143,7 @@ final class LegacyTestFrameworkBridgeTest extends TestCase
         ;
 
         $testFramework = $this->createTestFramework(
-            adapter: new FakeAwareAdapter(42.0),
+            adapter: $adapter,
             coverageChecker: $coverageChecker,
             initialTestsRunner: $initialTestsRunner,
         );
@@ -160,16 +161,18 @@ final class LegacyTestFrameworkBridgeTest extends TestCase
     public function test_it_forwards_initial_run_options(): void
     {
         $process = $this->createSuccessfulInitialRunProcess('output');
+        $adapter = new DummyTestFrameworkAdapter();
 
         $initialTestsRunner = $this->createMock(InitialTestsRunner::class);
         $initialTestsRunner
             ->expects($this->once())
             ->method('run')
-            ->with('--verbose', ['-d', 'memory_limit=1G'], true)
+            ->with($adapter, '--verbose', ['-d', 'memory_limit=1G'], true)
             ->willReturn($process)
         ;
 
         $testFramework = $this->createTestFramework(
+            adapter: $adapter,
             initialTestsRunner: $initialTestsRunner,
             initialTestsPhpOptions: '-d memory_limit=1G',
             testFrameworkExtraOptions: '--verbose',
@@ -255,15 +258,16 @@ final class LegacyTestFrameworkBridgeTest extends TestCase
     {
         $mutant = MutantBuilder::withMinimalTestData()->build();
         $processContainer = $this->createStub(MutantProcessContainer::class);
+        $adapter = new DummyTestFrameworkAdapter();
 
         $processFactoryMock = $this->createMock(MutantProcessContainerFactory::class);
         $processFactoryMock
             ->expects($this->once())
             ->method('create')
-            ->with($mutant, '')
+            ->with($adapter, $mutant, '')
             ->willReturn($processContainer);
 
-        $testFramework = $this->createTestFramework(processFactory: $processFactoryMock);
+        $testFramework = $this->createTestFramework(adapter: $adapter, processFactory: $processFactoryMock);
 
         $actual = $testFramework->test($mutant);
 
@@ -274,12 +278,13 @@ final class LegacyTestFrameworkBridgeTest extends TestCase
     {
         $mutant = MutantBuilder::withMinimalTestData()->build();
         $processContainer = $this->createStub(MutantProcessContainer::class);
+        $adapter = $this->createInitialRunOnlyOptionsAdapter();
 
         $processFactoryMock = $this->createMock(MutantProcessContainerFactory::class);
         $processFactoryMock
             ->expects($this->once())
             ->method('create')
-            ->with($mutant, '--filter FooTest')
+            ->with($adapter, $mutant, '--filter FooTest')
             ->willReturn($processContainer);
 
         $testFrameworkExtraOptionsFilter = $this->createMock(TestFrameworkExtraOptionsFilter::class);
@@ -291,7 +296,7 @@ final class LegacyTestFrameworkBridgeTest extends TestCase
         ;
 
         $testFramework = $this->createTestFramework(
-            adapter: $this->createInitialRunOnlyOptionsAdapter(),
+            adapter: $adapter,
             processFactory: $processFactoryMock,
             testFrameworkExtraOptionsFilter: $testFrameworkExtraOptionsFilter,
             testFrameworkExtraOptions: '--configuration phpunit.xml --filter FooTest',

--- a/tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php
+++ b/tests/phpunit/TestFramework/Tracing/Tracer/TracerIntegrationTest.php
@@ -35,8 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Tracing\Tracer;
 
-use Infection\AbstractTestFramework\TestFrameworkAdapter;
 use Infection\FileSystem\FileSystem;
+use Infection\TestFramework\Contracts\TestFramework;
 use Infection\TestFramework\Coverage\CoveredTraceProvider;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder;
 use Infection\TestFramework\Coverage\JUnit\JUnitTestFileDataProvider;
@@ -121,8 +121,8 @@ final class TracerIntegrationTest extends TestCase
         string $indexXmlPath,
         ?string $junitXmlPath,
     ): Tracer {
-        $testFrameworkAdapterStub = $this->createStub(TestFrameworkAdapter::class);
-        $testFrameworkAdapterStub
+        $testFrameworkStub = $this->createStub(TestFramework::class);
+        $testFrameworkStub
             ->method('hasJUnitReport')
             ->willReturn($junitXmlPath !== null);
 
@@ -149,7 +149,7 @@ final class TracerIntegrationTest extends TestCase
                     ),
                 ),
                 new JUnitTestExecutionInfoAdder(
-                    $testFrameworkAdapterStub,
+                    $testFrameworkStub,
                     $junitFileDataProvider,
                 ),
             ),


### PR DESCRIPTION
_Closed in favour of https://github.com/infection/infection/pull/3525 to leverage the GitHub stack feature._

<hr/>

## Description

This PR updates the code to use the new `TestFramework` API instead of `TestFrameworkAdapter`.

The immediate goal is to enable the introduction of `TestFrameworkFactory`. This requires removing `TestFrameworkAdapter`
from the container; otherwise, we would need either to create another test framework instance or to bridge the new API to
the old one, which is not feasible.

## Changes

This PR:

- Moves coverage requirement checks and the standalone initial test run behind `TestFramework`.
- Exposes JUnit report support on the contract for coverage enrichment and progress logging. This is only to facilitate the migration.
- Makes the bridge responsible for the legacy adapter and passes it explicitly to the remaining legacy process factories.
- Removes superseded adapter, coverage checker, and mutant result factory services from the container.

## Breaking Changes

None.

## Reviewer Notes

In the proof of concept in #3290, I retained the second instance because it was simpler. Although this should be safe because
the adapters are effectively stateless, avoiding the additional instance provides a cleaner solution.

This work also suggests the following changes for later PRs:

- Add PHPat rules that report uses of the legacy `TestFrameworkAdapter` and `TestFrameworkAdapterFactory` as deprecations.
  This would demonstrate how PRs such as this one resolve outstanding violations.
- In the proof of concept, I migrated `PHPUnitAdapter` directly, leaving the new code alongside the deprecated code.
  Introducing `LegacyPHPUnitAdapter` would provide a clearer boundary where the use of `TestFrameworkAdapter` and
  `TestFrameworkAdapterFactory` does not trigger a deprecation. This code should remain for as long as
  `TestFrameworkAdapter` is supported.
