### PR TITLE
fix(test-framework): Avoid mutating PATH during lookup

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -1610,12 +1610,6 @@ count = 1
 
 [[issues]]
 file = "src/FileSystem/Finder/TestFrameworkFinder.php"
-code = "possibly-false-operand"
-message = "Possibly false right operand used in string concatenation (type `false|string`)."
-count = 1
-
-[[issues]]
-file = "src/FileSystem/Finder/TestFrameworkFinder.php"
 code = "possibly-null-argument"
 message = "Argument #1 of function `trim` is possibly `null`, but parameter type `string` does not accept it."
 count = 1

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -49,6 +49,7 @@ use Infection\Config\ValueProvider\TextLogFileProvider;
 use Infection\Configuration\Schema\SchemaConfigurationLoader;
 use Infection\Console\IO;
 use Infection\FileSystem\FileSystem;
+use Infection\FileSystem\Finder\ComposerBinExecutableFinder;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Framework\InfectionVersion;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
@@ -164,6 +165,8 @@ final class ConfigureCommand extends BaseCommand
         $phpUnitExecutableFinder = new TestFrameworkFinder(
             $container->getComposerExecutableFinder(),
             $container->getShellCommandRunner(),
+            new ComposerBinExecutableFinder(),
+            $this->fileSystem,
         );
         $phpUnitCustomExecutablePathProvider = new PhpUnitCustomExecutablePathProvider($phpUnitExecutableFinder, $consoleHelper, $questionHelper);
         $phpUnitCustomExecutablePath = $phpUnitCustomExecutablePathProvider->get($io);

--- a/src/FileSystem/Finder/ComposerBinExecutableFinder.php
+++ b/src/FileSystem/Finder/ComposerBinExecutableFinder.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\FileSystem\Finder;
+
+use function explode;
+use Infection\CannotBeInstantiated;
+use function is_executable;
+use function is_file;
+
+/**
+ * @internal
+ */
+final class ComposerBinExecutableFinder
+{
+    use CannotBeInstantiated;
+
+    private const string WINDOWS = 'Windows';
+
+    private const string WINDOWS_PATH_SEPARATOR = ';';
+
+    private const array DEFAULT_WINDOWS_EXECUTABLE_SUFFIXES = ['.exe', '.bat', '.cmd', '.com'];
+
+    /**
+     * @param list<string> $candidates
+     */
+    public static function find(
+        array $candidates,
+        string $composerBinDir,
+        string $operatingSystemFamily,
+        string|false $pathExtension,
+    ): ?string {
+        $windowsSuffixes = $pathExtension === false || $pathExtension === ''
+            ? self::DEFAULT_WINDOWS_EXECUTABLE_SUFFIXES
+            : explode(self::WINDOWS_PATH_SEPARATOR, $pathExtension);
+        $suffixes = $operatingSystemFamily === self::WINDOWS ? $windowsSuffixes : [];
+
+        // The caller searches PATH only after this directory. Checking every local candidate
+        // here prevents a PATH .bat from outranking an extensionless Composer proxy.
+        foreach ($candidates as $name) {
+            foreach (['', ...$suffixes] as $suffix) {
+                $composerCandidate = $composerBinDir . '/' . $name . $suffix;
+
+                if (
+                    is_file($composerCandidate)
+                    && ($operatingSystemFamily === self::WINDOWS || is_executable($composerCandidate))
+                ) {
+                    return $composerCandidate;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FileSystem/Finder/ComposerBinExecutableFinder.php
+++ b/src/FileSystem/Finder/ComposerBinExecutableFinder.php
@@ -36,17 +36,15 @@ declare(strict_types=1);
 namespace Infection\FileSystem\Finder;
 
 use function explode;
-use Infection\CannotBeInstantiated;
 use function is_executable;
 use function is_file;
 
 /**
  * @internal
+ * @final
  */
-final class ComposerBinExecutableFinder
+class ComposerBinExecutableFinder
 {
-    use CannotBeInstantiated;
-
     private const string WINDOWS = 'Windows';
 
     private const string WINDOWS_PATH_SEPARATOR = ';';
@@ -56,21 +54,24 @@ final class ComposerBinExecutableFinder
     /**
      * @param list<string> $candidates
      */
-    public static function find(
+    public function find(
         array $candidates,
         string $composerBinDir,
         string $operatingSystemFamily,
         string|false $pathExtension,
     ): ?string {
-        $windowsSuffixes = $pathExtension === false || $pathExtension === ''
-            ? self::DEFAULT_WINDOWS_EXECUTABLE_SUFFIXES
-            : explode(self::WINDOWS_PATH_SEPARATOR, $pathExtension);
-        $suffixes = $operatingSystemFamily === self::WINDOWS ? $windowsSuffixes : [];
+        $suffixes = [''];
 
-        // The caller searches PATH only after this directory. Checking every local candidate
-        // here prevents a PATH .bat from outranking an extensionless Composer proxy.
+        if ($operatingSystemFamily === self::WINDOWS) {
+            $windowsSuffixes = $pathExtension === false || $pathExtension === ''
+                ? self::DEFAULT_WINDOWS_EXECUTABLE_SUFFIXES
+                : explode(self::WINDOWS_PATH_SEPARATOR, $pathExtension);
+
+            $suffixes = ['', ...$windowsSuffixes];
+        }
+
         foreach ($candidates as $name) {
-            foreach (['', ...$suffixes] as $suffix) {
+            foreach ($suffixes as $suffix) {
                 $composerCandidate = $composerBinDir . '/' . $name . $suffix;
 
                 if (

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -37,8 +37,8 @@ namespace Infection\FileSystem\Finder;
 
 use function array_key_exists;
 use function dirname;
-use function file_exists;
 use function getenv as getenv_unsafe;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\TestFramework\Contracts\ShellCommandRunner;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -70,6 +70,8 @@ class TestFrameworkFinder
     public function __construct(
         private readonly ComposerExecutableFinder $executableFinder,
         private readonly ShellCommandRunner $shellCommandRunner,
+        private readonly ComposerBinExecutableFinder $composerBinExecutableFinder,
+        private readonly FileSystem $fileSystem,
     ) {
     }
 
@@ -100,7 +102,7 @@ class TestFrameworkFinder
             return false;
         }
 
-        if (file_exists($customPath)) {
+        if ($this->fileSystem->exists($customPath)) {
             return true;
         }
 
@@ -147,7 +149,7 @@ class TestFrameworkFinder
         $extraDirs = [$cwd, $cwd . '/bin'];
 
         if ($composerBinDir !== null) {
-            $composerExecutable = ComposerBinExecutableFinder::find(
+            $composerExecutable = $this->composerBinExecutableFinder->find(
                 $candidates,
                 $composerBinDir,
                 PHP_OS_FAMILY,
@@ -171,7 +173,7 @@ class TestFrameworkFinder
             foreach ($candidates as $name) {
                 $composerCandidate = $composerBinDir . '/' . $name;
 
-                if (file_exists($composerCandidate)) {
+                if ($this->fileSystem->exists($composerCandidate)) {
                     return $composerCandidate;
                 }
             }
@@ -202,7 +204,7 @@ class TestFrameworkFinder
             $target = ltrim(rtrim(trim($match[1]), '" %*'), '\\/');
             $script = realpath(dirname($path) . '/' . $target);
 
-            if (file_exists($script)) {
+            if ($this->fileSystem->exists($script)) {
                 $path = $script;
             }
         }
@@ -228,7 +230,7 @@ class TestFrameworkFinder
 
         $candidate = getcwd() . '/vendor/bin';
 
-        if (file_exists($candidate)) {
+        if ($this->fileSystem->exists($candidate)) {
             return $candidate;
         }
 

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -36,20 +36,20 @@ declare(strict_types=1);
 namespace Infection\FileSystem\Finder;
 
 use function array_key_exists;
+use const DIRECTORY_SEPARATOR;
 use function dirname;
 use function file_exists;
-use function getenv;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\TestFramework\Contracts\ShellCommandRunner;
 use Infection\TestFramework\TestFrameworkTypes;
+use function is_executable;
+use function is_file;
 use function ltrim;
-use const PATH_SEPARATOR;
 use function rtrim;
 use RuntimeException;
 use function Safe\file_get_contents;
 use function Safe\getcwd;
 use function Safe\preg_match;
-use function Safe\putenv;
 use function Safe\realpath;
 use function substr;
 use Symfony\Component\Process\ExecutableFinder;
@@ -77,11 +77,13 @@ class TestFrameworkFinder
     public function find(string $testFrameworkName, string $customPath = ''): string
     {
         if (!array_key_exists($testFrameworkName, $this->cachedPath)) {
-            if (!$this->shouldUseCustomPath($testFrameworkName, $customPath)) {
-                $this->addComposerBinToPath();
-            }
+            $composerBinDir = $this->shouldUseCustomPath($testFrameworkName, $customPath)
+                ? null
+                : $this->getComposerBinDir();
 
-            $this->cachedPath[$testFrameworkName] = realpath($this->findTestFramework($testFrameworkName, $customPath));
+            $this->cachedPath[$testFrameworkName] = realpath(
+                $this->findTestFramework($testFrameworkName, $customPath, $composerBinDir),
+            );
 
             Assert::string($this->cachedPath[$testFrameworkName]);
 
@@ -106,16 +108,6 @@ class TestFrameworkFinder
         throw FinderException::testCustomPathDoesNotExist($testFrameworkName, $customPath);
     }
 
-    private function addComposerBinToPath(): void
-    {
-        $composerBinDir = $this->getComposerBinDir();
-
-        if ($composerBinDir !== null) {
-            $pathName = getenv('PATH') !== false ? 'PATH' : 'Path';
-            putenv($pathName . '=' . $composerBinDir . PATH_SEPARATOR . getenv($pathName));
-        }
-    }
-
     /**
      * @return list<string>
      */
@@ -124,8 +116,11 @@ class TestFrameworkFinder
         return $this->executableFinder->find();
     }
 
-    private function findTestFramework(string $testFrameworkName, string $customPath): string
-    {
+    private function findTestFramework(
+        string $testFrameworkName,
+        string $customPath,
+        ?string $composerBinDir,
+    ): string {
         if ($this->shouldUseCustomPath($testFrameworkName, $customPath)) {
             return $customPath;
         }
@@ -153,10 +148,31 @@ class TestFrameworkFinder
         $extraDirs = [$cwd, $cwd . '/bin'];
 
         foreach ($candidates as $name) {
+            if ($composerBinDir !== null) {
+                $composerCandidate = $composerBinDir . '/' . $name;
+
+                if (
+                    is_file($composerCandidate)
+                    && (DIRECTORY_SEPARATOR === '\\' || is_executable($composerCandidate))
+                ) {
+                    return $composerCandidate;
+                }
+            }
+
             $path = $finder->find($name, null, $extraDirs);
 
             if ($path !== null) {
                 return $path;
+            }
+        }
+
+        if ($composerBinDir !== null) {
+            foreach ($candidates as $name) {
+                $composerCandidate = $composerBinDir . '/' . $name;
+
+                if (file_exists($composerCandidate)) {
+                    return $composerCandidate;
+                }
             }
         }
 

--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -36,15 +36,14 @@ declare(strict_types=1);
 namespace Infection\FileSystem\Finder;
 
 use function array_key_exists;
-use const DIRECTORY_SEPARATOR;
 use function dirname;
 use function file_exists;
+use function getenv as getenv_unsafe;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\TestFramework\Contracts\ShellCommandRunner;
 use Infection\TestFramework\TestFrameworkTypes;
-use function is_executable;
-use function is_file;
 use function ltrim;
+use const PHP_OS_FAMILY;
 use function rtrim;
 use RuntimeException;
 use function Safe\file_get_contents;
@@ -147,18 +146,20 @@ class TestFrameworkFinder
         $cwd = getcwd();
         $extraDirs = [$cwd, $cwd . '/bin'];
 
-        foreach ($candidates as $name) {
-            if ($composerBinDir !== null) {
-                $composerCandidate = $composerBinDir . '/' . $name;
+        if ($composerBinDir !== null) {
+            $composerExecutable = ComposerBinExecutableFinder::find(
+                $candidates,
+                $composerBinDir,
+                PHP_OS_FAMILY,
+                getenv_unsafe('PATHEXT'),
+            );
 
-                if (
-                    is_file($composerCandidate)
-                    && (DIRECTORY_SEPARATOR === '\\' || is_executable($composerCandidate))
-                ) {
-                    return $composerCandidate;
-                }
+            if ($composerExecutable !== null) {
+                return $composerExecutable;
             }
+        }
 
+        foreach ($candidates as $name) {
             $path = $finder->find($name, null, $extraDirs);
 
             if ($path !== null) {

--- a/tests/phpunit/FileSystem/Finder/ComposerBinExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/ComposerBinExecutableFinderTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem\Finder;
 
+use function getenv;
 use Infection\FileSystem\Finder\ComposerBinExecutableFinder;
 use Infection\Tests\FileSystem\FileSystemTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -48,22 +49,45 @@ use Symfony\Component\Filesystem\Filesystem;
 #[CoversClass(ComposerBinExecutableFinder::class)]
 final class ComposerBinExecutableFinderTest extends FileSystemTestCase
 {
+    private ComposerBinExecutableFinder $finder;
+
     private Filesystem $fileSystem;
 
     protected function setUp(): void
     {
         parent::setUp();
 
+        $this->finder = new ComposerBinExecutableFinder();
         $this->fileSystem = new Filesystem();
     }
 
-    public function test_it_finds_a_windows_path_extension_candidate(): void
+    #[DataProvider('provideWindowsPathExtensionCandidate')]
+    public function test_it_finds_a_windows_path_extension_candidate(string $name): void
     {
-        $candidate = $this->createCandidate('phpunit.cmd');
+        $candidate = $this->createCandidate($name);
+        $path = getenv('PATH');
 
         $this->assertSame(
             $candidate,
-            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Windows', '.cmd;.exe'),
+            $this->finder->find(['phpunit'], $this->tmp, 'Windows', '.cmd;.exe'),
+        );
+        $this->assertSame($path, getenv('PATH'));
+    }
+
+    public static function provideWindowsPathExtensionCandidate(): iterable
+    {
+        yield 'CMD executable' => ['name' => 'phpunit.cmd'];
+
+        yield 'EXE executable after CMD' => ['name' => 'phpunit.exe'];
+    }
+
+    public function test_it_prioritizes_an_extensionless_windows_candidate(): void
+    {
+        $candidate = $this->createCandidate('phpunit', 0644);
+
+        $this->assertSame(
+            $candidate,
+            $this->finder->find(['phpunit'], $this->tmp, 'Windows', '.cmd'),
         );
     }
 
@@ -74,7 +98,7 @@ final class ComposerBinExecutableFinderTest extends FileSystemTestCase
 
         $this->assertSame(
             $candidate,
-            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Windows', $pathExtension),
+            $this->finder->find(['phpunit'], $this->tmp, 'Windows', $pathExtension),
         );
     }
 
@@ -90,7 +114,7 @@ final class ComposerBinExecutableFinderTest extends FileSystemTestCase
         $this->createCandidate('phpunit.cmd');
 
         $this->assertNull(
-            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Darwin', '.cmd'),
+            $this->finder->find(['phpunit'], $this->tmp, 'Darwin', '.cmd'),
         );
     }
 
@@ -101,7 +125,7 @@ final class ComposerBinExecutableFinderTest extends FileSystemTestCase
 
         $this->assertSame(
             $candidate,
-            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Linux', false),
+            $this->finder->find(['phpunit'], $this->tmp, 'Linux', false),
         );
     }
 

--- a/tests/phpunit/FileSystem/Finder/ComposerBinExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/ComposerBinExecutableFinderTest.php
@@ -40,6 +40,7 @@ use Infection\Tests\FileSystem\FileSystemTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 use function Safe\chmod;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -93,6 +94,7 @@ final class ComposerBinExecutableFinderTest extends FileSystemTestCase
         );
     }
 
+    #[RequiresOperatingSystem('Linux|Darwin')]
     public function test_it_finds_an_executable_candidate_on_other_systems(): void
     {
         $candidate = $this->createCandidate('phpunit');

--- a/tests/phpunit/FileSystem/Finder/ComposerBinExecutableFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/ComposerBinExecutableFinderTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\FileSystem\Finder;
+
+use Infection\FileSystem\Finder\ComposerBinExecutableFinder;
+use Infection\Tests\FileSystem\FileSystemTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use function Safe\chmod;
+use Symfony\Component\Filesystem\Filesystem;
+
+#[Group('integration')]
+#[CoversClass(ComposerBinExecutableFinder::class)]
+final class ComposerBinExecutableFinderTest extends FileSystemTestCase
+{
+    private Filesystem $fileSystem;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fileSystem = new Filesystem();
+    }
+
+    public function test_it_finds_a_windows_path_extension_candidate(): void
+    {
+        $candidate = $this->createCandidate('phpunit.cmd');
+
+        $this->assertSame(
+            $candidate,
+            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Windows', '.cmd;.exe'),
+        );
+    }
+
+    #[DataProvider('provideMissingWindowsPathExtension')]
+    public function test_it_uses_default_windows_path_extensions(string|false $pathExtension): void
+    {
+        $candidate = $this->createCandidate('phpunit.exe', 0644);
+
+        $this->assertSame(
+            $candidate,
+            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Windows', $pathExtension),
+        );
+    }
+
+    public static function provideMissingWindowsPathExtension(): iterable
+    {
+        yield 'missing variable' => ['pathExtension' => false];
+
+        yield 'empty variable' => ['pathExtension' => ''];
+    }
+
+    public function test_it_ignores_windows_path_extensions_on_other_systems(): void
+    {
+        $this->createCandidate('phpunit.cmd');
+
+        $this->assertNull(
+            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Darwin', '.cmd'),
+        );
+    }
+
+    public function test_it_finds_an_executable_candidate_on_other_systems(): void
+    {
+        $candidate = $this->createCandidate('phpunit');
+
+        $this->assertSame(
+            $candidate,
+            ComposerBinExecutableFinder::find(['phpunit'], $this->tmp, 'Linux', false),
+        );
+    }
+
+    private function createCandidate(string $name, int $permissions = 0755): string
+    {
+        $path = $this->tmp . '/' . $name;
+        $this->fileSystem->dumpFile($path, '#!/usr/bin/env php');
+        chmod($path, $permissions);
+
+        return $path;
+    }
+}

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -49,6 +49,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
 use PHPUnit\Framework\Attributes\WithEnvironmentVariable;
 use PHPUnit\Framework\MockObject\Stub;
 use RuntimeException;
@@ -175,7 +176,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $this->assertSame($path, self::getPath());
     }
 
-    #[RequiresOperatingSystem('Windows')]
+    #[RequiresOperatingSystemFamily('Windows')]
     #[DataProvider('provideWindowsPathExtensions')]
     public function test_it_applies_windows_path_extensions_in_composer_bin_without_modifying_path(
         string $extension,
@@ -210,7 +211,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         yield 'EXE executable' => ['extension' => '.exe'];
     }
 
-    #[RequiresOperatingSystem('Windows')]
+    #[RequiresOperatingSystemFamily('Windows')]
     public function test_it_prioritizes_an_extensionless_composer_proxy_over_a_path_batch_file(): void
     {
         chdir($this->tmp);

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -136,14 +136,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $path = self::getPath();
 
-        $shellCommandRunner = $this->createMock(ShellCommandRunner::class);
-        $shellCommandRunner
-            ->expects($this->once())
-            ->method('mustRun')
-            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
-            ->willReturn($composerBinDir);
-
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $shellCommandRunner);
+        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
 
         $this->assertSame(
             Path::normalize($composerBinExecutable),
@@ -172,20 +165,103 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $path = self::getPath();
 
-        $shellCommandRunner = $this->createMock(ShellCommandRunner::class);
-        $shellCommandRunner
-            ->expects($this->once())
-            ->method('mustRun')
-            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
-            ->willReturn($composerBinDir);
-
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $shellCommandRunner);
+        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
 
         $this->assertSame(
             Path::normalize($pathExecutable),
             Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
         );
 
+        $this->assertSame($path, self::getPath());
+    }
+
+    #[RequiresOperatingSystem('Windows')]
+    #[DataProvider('provideWindowsPathExtensions')]
+    public function test_it_applies_windows_path_extensions_in_composer_bin_without_modifying_path(
+        string $extension,
+    ): void {
+        chdir($this->tmp);
+
+        $composerBinDir = $this->tmp . '/composer-bin';
+        mkdir($composerBinDir);
+        $composerExecutable = $this->createPhpUnitExecutableFixture($composerBinDir, $extension);
+
+        $pathBinDir = $this->tmp . '/path-bin';
+        mkdir($pathBinDir);
+
+        putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
+        putenv(sprintf('PATHEXT=%s', $extension));
+
+        $path = self::getPath();
+
+        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
+
+        $this->assertSame(
+            Path::normalize($composerExecutable),
+            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
+        );
+        $this->assertSame($path, self::getPath());
+    }
+
+    public static function provideWindowsPathExtensions(): iterable
+    {
+        yield 'CMD executable' => ['extension' => '.cmd'];
+
+        yield 'EXE executable' => ['extension' => '.exe'];
+    }
+
+    #[RequiresOperatingSystem('Windows')]
+    public function test_it_prioritizes_an_extensionless_composer_proxy_over_a_path_batch_file(): void
+    {
+        chdir($this->tmp);
+
+        $composerBinDir = $this->tmp . '/composer-bin';
+        mkdir($composerBinDir);
+        $composerExecutable = $this->createPhpUnitExecutableFixture($composerBinDir);
+
+        $pathBinDir = $this->tmp . '/path-bin';
+        mkdir($pathBinDir);
+        $this->createPhpUnitExecutableFixture($pathBinDir, '.bat');
+
+        putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
+        putenv('PATHEXT=.bat');
+
+        $path = self::getPath();
+
+        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
+
+        $this->assertSame(
+            Path::normalize($composerExecutable),
+            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
+        );
+        $this->assertSame($path, self::getPath());
+    }
+
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function test_it_prioritizes_a_non_executable_composer_candidate_over_a_non_executable_path_candidate(): void
+    {
+        chdir($this->tmp);
+
+        $composerBinDir = $this->tmp . '/composer-bin';
+        mkdir($composerBinDir);
+        $composerCandidate = $this->createPhpUnitExecutableFixture($composerBinDir);
+        chmod($composerCandidate, 0644);
+
+        $pathBinDir = $this->tmp . '/path-bin';
+        mkdir($pathBinDir);
+        chmod($this->createPhpUnitExecutableFixture($pathBinDir), 0644);
+
+        putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
+        putenv('PATHEXT=');
+
+        $path = self::getPath();
+
+        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
+
+        $this->assertSame(
+            Path::normalize($composerCandidate),
+            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
+        );
         $this->assertSame($path, self::getPath());
     }
 
@@ -387,6 +463,18 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         return $path === false ? '' : $path;
     }
 
+    private function createFinderWithComposerBin(string $composerBinDir): TestFrameworkFinder
+    {
+        $shellCommandRunner = $this->createMock(ShellCommandRunner::class);
+        $shellCommandRunner
+            ->expects($this->once())
+            ->method('mustRun')
+            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
+            ->willReturn($composerBinDir);
+
+        return new TestFrameworkFinder($this->composerFinder, $shellCommandRunner);
+    }
+
     private function createComposerExecutableFixture(): string
     {
         $composerBinDir = $this->tmp . '/composer-bin';
@@ -414,9 +502,9 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         return $composerBinDir;
     }
 
-    private function createPhpUnitExecutableFixture(string $composerBinDir): string
+    private function createPhpUnitExecutableFixture(string $composerBinDir, string $suffix = ''): string
     {
-        $phpUnitPath = $composerBinDir . '/phpunit';
+        $phpUnitPath = $composerBinDir . '/phpunit' . $suffix;
         $this->fileSystem->dumpFile($phpUnitPath, '#!/usr/bin/env php');
         chmod($phpUnitPath, 0755);
 

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -36,6 +36,8 @@ declare(strict_types=1);
 namespace Infection\Tests\FileSystem\Finder;
 
 use function getenv;
+use Infection\FileSystem\FileSystem;
+use Infection\FileSystem\Finder\ComposerBinExecutableFinder;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
@@ -49,7 +51,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
-use PHPUnit\Framework\Attributes\RequiresOperatingSystemFamily;
 use PHPUnit\Framework\Attributes\WithEnvironmentVariable;
 use PHPUnit\Framework\MockObject\Stub;
 use RuntimeException;
@@ -58,7 +59,6 @@ use function Safe\chmod;
 use function Safe\mkdir;
 use function Safe\putenv;
 use function sprintf;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
 /**
@@ -73,7 +73,9 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 {
     private const string PATH_NAME = 'PATH';
 
-    private Filesystem $fileSystem;
+    private ComposerBinExecutableFinder $composerBinExecutableFinder;
+
+    private FileSystem $fileSystem;
 
     private ComposerExecutableFinder&Stub $composerFinder;
 
@@ -87,7 +89,9 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         // root.
         chdir(__DIR__ . '/../../../../');
 
-        $this->fileSystem = new Filesystem();
+        $this->fileSystem = new FileSystem();
+
+        $this->composerBinExecutableFinder = new ComposerBinExecutableFinder();
 
         $this->composerFinder = $this->createStub(ComposerExecutableFinder::class);
         $this->composerFinder->method('find')
@@ -101,7 +105,12 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
     {
         $filename = $this->fileSystem->tempnam($this->tmp, 'test');
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandRunner);
+        $frameworkFinder = new TestFrameworkFinder(
+            $this->composerFinder,
+            $this->shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
+        );
 
         $this->assertSame($filename, $frameworkFinder->find('not-used', $filename), 'Should return the custom path');
     }
@@ -112,7 +121,12 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         // Remove it so that the file doesn't exist
         $this->fileSystem->remove($filename);
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandRunner);
+        $frameworkFinder = new TestFrameworkFinder(
+            $this->composerFinder,
+            $this->shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
+        );
 
         $this->expectException(FinderException::class);
         $this->expectExceptionMessage('custom path');
@@ -120,42 +134,47 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $frameworkFinder->find('not-used', $filename);
     }
 
-    public function test_it_prioritizes_composer_bin_without_modifying_path(): void
+    public function test_it_prioritizes_an_extensionless_composer_proxy_over_a_path_batch_file_without_modifying_path(): void
     {
         chdir($this->tmp);
 
         $composerBinDir = $this->tmp . '/composer-bin';
-        mkdir($composerBinDir);
-        $composerBinExecutable = $this->createPhpUnitExecutableFixture($composerBinDir);
+        $composerExecutable = $this->createPhpUnitExecutableFixture($this->tmp);
 
         $pathBinDir = $this->tmp . '/path-bin';
         mkdir($pathBinDir);
-        $this->createPhpUnitExecutableFixture($pathBinDir);
+        $this->createPhpUnitExecutableFixture($pathBinDir, '.bat');
 
         putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
-        putenv('PATHEXT=');
+        putenv('PATHEXT=.bat');
 
         $path = self::getPath();
 
-        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
+        $composerBinExecutableFinder = $this->createMock(ComposerBinExecutableFinder::class);
+        $composerBinExecutableFinder
+            ->expects($this->once())
+            ->method('find')
+            ->willReturn($composerExecutable)
+        ;
 
-        $this->assertSame(
-            Path::normalize($composerBinExecutable),
-            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
-            'Should return the phpunit path',
+        $frameworkFinder = $this->createFinderWithComposerBin(
+            $composerBinDir,
+            $composerBinExecutableFinder,
         );
 
+        $this->assertSame(
+            Path::normalize($composerExecutable),
+            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
+        );
         $this->assertSame($path, self::getPath());
     }
 
     #[RequiresOperatingSystem('Linux|Darwin')]
-    public function test_it_uses_path_when_the_composer_bin_candidate_is_not_executable(): void
+    public function test_it_uses_path_when_composer_bin_has_no_executable_candidate(): void
     {
         chdir($this->tmp);
 
         $composerBinDir = $this->tmp . '/composer-bin';
-        mkdir($composerBinDir);
-        chmod($this->createPhpUnitExecutableFixture($composerBinDir), 0644);
 
         $pathBinDir = $this->tmp . '/path-bin';
         mkdir($pathBinDir);
@@ -173,68 +192,6 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
             Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
         );
 
-        $this->assertSame($path, self::getPath());
-    }
-
-    #[RequiresOperatingSystemFamily('Windows')]
-    #[DataProvider('provideWindowsPathExtensions')]
-    public function test_it_applies_windows_path_extensions_in_composer_bin_without_modifying_path(
-        string $extension,
-    ): void {
-        chdir($this->tmp);
-
-        $composerBinDir = $this->tmp . '/composer-bin';
-        mkdir($composerBinDir);
-        $composerExecutable = $this->createPhpUnitExecutableFixture($composerBinDir, $extension);
-
-        $pathBinDir = $this->tmp . '/path-bin';
-        mkdir($pathBinDir);
-
-        putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
-        putenv(sprintf('PATHEXT=%s', $extension));
-
-        $path = self::getPath();
-
-        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
-
-        $this->assertSame(
-            Path::normalize($composerExecutable),
-            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
-        );
-        $this->assertSame($path, self::getPath());
-    }
-
-    public static function provideWindowsPathExtensions(): iterable
-    {
-        yield 'CMD executable' => ['extension' => '.cmd'];
-
-        yield 'EXE executable' => ['extension' => '.exe'];
-    }
-
-    #[RequiresOperatingSystemFamily('Windows')]
-    public function test_it_prioritizes_an_extensionless_composer_proxy_over_a_path_batch_file(): void
-    {
-        chdir($this->tmp);
-
-        $composerBinDir = $this->tmp . '/composer-bin';
-        mkdir($composerBinDir);
-        $composerExecutable = $this->createPhpUnitExecutableFixture($composerBinDir);
-
-        $pathBinDir = $this->tmp . '/path-bin';
-        mkdir($pathBinDir);
-        $this->createPhpUnitExecutableFixture($pathBinDir, '.bat');
-
-        putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
-        putenv('PATHEXT=.bat');
-
-        $path = self::getPath();
-
-        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
-
-        $this->assertSame(
-            Path::normalize($composerExecutable),
-            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
-        );
         $this->assertSame($path, self::getPath());
     }
 
@@ -257,7 +214,20 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
 
         $path = self::getPath();
 
-        $frameworkFinder = $this->createFinderWithComposerBin($composerBinDir);
+        $fileSystem = $this->createMock(FileSystem::class);
+        $fileSystem
+            ->expects($this->exactly(2))
+            ->method('exists')
+            ->willReturnMap([
+                [$composerBinDir . '/phpunit.bat', false],
+                [$composerCandidate, true],
+            ])
+        ;
+
+        $frameworkFinder = $this->createFinderWithComposerBin(
+            $composerBinDir,
+            fileSystem: $fileSystem,
+        );
 
         $this->assertSame(
             Path::normalize($composerCandidate),
@@ -287,6 +257,8 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $frameworkFinder = new TestFrameworkFinder(
             $this->composerFinder,
             $shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
         );
 
         if (OperatingSystem::isWindows()) {
@@ -336,6 +308,8 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $frameworkFinder = new TestFrameworkFinder(
             $this->composerFinder,
             $shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
         );
 
         $actual = Path::canonicalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT));
@@ -373,6 +347,8 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $frameworkFinder = new TestFrameworkFinder(
             new ConcreteComposerExecutableFinder(),
             $this->shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
         );
 
         $expected = Path::canonicalize($fallbackExecutable);
@@ -395,6 +371,8 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $frameworkFinder = new TestFrameworkFinder(
             new ConcreteComposerExecutableFinder(),
             $this->shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
         );
 
         $expected = Path::canonicalize($phpUnitPath);
@@ -415,7 +393,12 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::PATH_NAME, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandRunner);
+        $frameworkFinder = new TestFrameworkFinder(
+            $this->composerFinder,
+            $this->shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
+        );
 
         if (OperatingSystem::isWindows()) {
             // This .bat has no code, so main script will not be found
@@ -441,7 +424,12 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         putenv(sprintf('%s=%s', self::PATH_NAME, $mock->getVendorBinDir()));
         putenv('PATHEXT=');
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandRunner);
+        $frameworkFinder = new TestFrameworkFinder(
+            $this->composerFinder,
+            $this->shellCommandRunner,
+            $this->composerBinExecutableFinder,
+            $this->fileSystem,
+        );
 
         $this->assertSame(
             Path::canonicalize($mock->getPackageScript()),
@@ -464,16 +452,25 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         return $path === false ? '' : $path;
     }
 
-    private function createFinderWithComposerBin(string $composerBinDir): TestFrameworkFinder
-    {
+    private function createFinderWithComposerBin(
+        string $composerBinDir,
+        ?ComposerBinExecutableFinder $composerBinExecutableFinder = null,
+        ?FileSystem $fileSystem = null,
+    ): TestFrameworkFinder {
         $shellCommandRunner = $this->createMock(ShellCommandRunner::class);
         $shellCommandRunner
             ->expects($this->once())
             ->method('mustRun')
             ->with(['/usr/bin/composer', 'config', 'bin-dir'])
-            ->willReturn($composerBinDir);
+            ->willReturn($composerBinDir)
+        ;
 
-        return new TestFrameworkFinder($this->composerFinder, $shellCommandRunner);
+        return new TestFrameworkFinder(
+            $this->composerFinder,
+            $shellCommandRunner,
+            $composerBinExecutableFinder ?? $this->composerBinExecutableFinder,
+            $fileSystem ?? $this->fileSystem,
+        );
     }
 
     private function createComposerExecutableFixture(): string

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -35,7 +35,6 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem\Finder;
 
-use function explode;
 use function getenv;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
@@ -46,7 +45,6 @@ use Infection\Process\SymfonyProcessShellCommandRunner;
 use Infection\TestFramework\Contracts\ShellCommandRunner;
 use Infection\TestFramework\TestFrameworkTypes;
 use Infection\Tests\FileSystem\FileSystemTestCase;
-use const PATH_SEPARATOR;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -58,9 +56,7 @@ use function Safe\chdir;
 use function Safe\chmod;
 use function Safe\mkdir;
 use function Safe\putenv;
-use function Safe\realpath;
 use function sprintf;
-use function strlen;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
@@ -123,33 +119,74 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $frameworkFinder->find('not-used', $filename);
     }
 
-    public function test_it_adds_vendor_bin_to_path_if_needed(): void
+    public function test_it_prioritizes_composer_bin_without_modifying_path(): void
     {
+        chdir($this->tmp);
+
+        $composerBinDir = $this->tmp . '/composer-bin';
+        mkdir($composerBinDir);
+        $composerBinExecutable = $this->createPhpUnitExecutableFixture($composerBinDir);
+
+        $pathBinDir = $this->tmp . '/path-bin';
+        mkdir($pathBinDir);
+        $this->createPhpUnitExecutableFixture($pathBinDir);
+
+        putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
+        putenv('PATHEXT=');
+
         $path = self::getPath();
 
-        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $this->shellCommandRunner);
+        $shellCommandRunner = $this->createMock(ShellCommandRunner::class);
+        $shellCommandRunner
+            ->expects($this->once())
+            ->method('mustRun')
+            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
+            ->willReturn($composerBinDir);
 
-        $expected = realpath('vendor/bin/phpunit');
+        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $shellCommandRunner);
 
         $this->assertSame(
-            Path::normalize($expected),
+            Path::normalize($composerBinExecutable),
             Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
             'Should return the phpunit path',
         );
 
-        $pathAfterTest = self::getPath();
+        $this->assertSame($path, self::getPath());
+    }
 
-        // Vendor bin should be the first item
-        $pathList = explode(PATH_SEPARATOR, $pathAfterTest);
-        $this->assertStringContainsString('vendor', $pathList[0]);
+    #[RequiresOperatingSystem('Linux|Darwin')]
+    public function test_it_uses_path_when_the_composer_bin_candidate_is_not_executable(): void
+    {
+        chdir($this->tmp);
 
-        $this->assertNotSame($path, $pathAfterTest);
+        $composerBinDir = $this->tmp . '/composer-bin';
+        mkdir($composerBinDir);
+        chmod($this->createPhpUnitExecutableFixture($composerBinDir), 0644);
 
-        $this->assertGreaterThan(
-            strlen($path),
-            strlen($pathAfterTest),
-            'PATH with vendor added is shorter than without it added, make sure it isn\'t overwritten.',
+        $pathBinDir = $this->tmp . '/path-bin';
+        mkdir($pathBinDir);
+        $pathExecutable = $this->createPhpUnitExecutableFixture($pathBinDir);
+
+        putenv(sprintf('%s=%s', self::PATH_NAME, $pathBinDir));
+        putenv('PATHEXT=');
+
+        $path = self::getPath();
+
+        $shellCommandRunner = $this->createMock(ShellCommandRunner::class);
+        $shellCommandRunner
+            ->expects($this->once())
+            ->method('mustRun')
+            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
+            ->willReturn($composerBinDir);
+
+        $frameworkFinder = new TestFrameworkFinder($this->composerFinder, $shellCommandRunner);
+
+        $this->assertSame(
+            Path::normalize($pathExecutable),
+            Path::normalize($frameworkFinder->find(TestFrameworkTypes::PHPUNIT)),
         );
+
+        $this->assertSame($path, self::getPath());
     }
 
     public function test_it_falls_back_to_local_vendor_bin_when_composer_command_fails(): void
@@ -187,13 +224,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
             Path::canonicalize($frameworkFinder->find($mock::PACKAGE)),
         );
 
-        $pathAfterTest = self::getPath();
-        $pathList = explode(PATH_SEPARATOR, $pathAfterTest);
-
-        $this->assertSame(
-            Path::canonicalize($this->tmp . '/vendor/bin'),
-            Path::canonicalize($pathList[0]),
-        );
+        $this->assertSame($this->tmp, self::getPath());
     }
 
     #[DataProvider('provideEmptyComposerBinDirCases')]
@@ -273,7 +304,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function test_it_adds_vendor_bin_to_path_with_a_local_composer_phar(): void
+    public function test_it_finds_vendor_bin_with_a_local_composer_phar_without_modifying_path(): void
     {
         chdir($this->tmp);
 
@@ -295,6 +326,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         );
 
         $this->assertSame($expected, $actual);
+        $this->assertSame($this->tmp, self::getPath());
     }
 
     public function test_it_finds_framework_executable(): void


### PR DESCRIPTION
## Description

`TestFrameworkFinder` currently prepends Composer's bin directory to the process-wide `PATH`. That lookup side effect leaks into later executable resolution and child processes.

This keeps Composer-bin-first resolution for test-framework candidates while leaving the process environment unchanged.

## Changes

- Resolve every executable candidate in Composer's configured bin directory before consulting the original `PATH`.
- Apply Windows `PATHEXT` suffixes inside Composer's bin directory, including the normal fallback suffixes when `PATHEXT` is absent.
- Preserve Windows `.bat` handling and Unix non-executable fallback precedence.
- Make directory precedence explicit on Windows: an extensionless Composer-bin proxy now wins over a `PATH` `.bat` proxy.
- Inject Composer-bin resolution into `TestFrameworkFinder` and use Infection's filesystem abstraction for existence checks.
- Add focused regressions for `PATH` stability, Windows `.cmd`/`.exe` lookup, Windows directory precedence, and Unix non-executable fallback.
- Remove the Mago baseline entry made obsolete by deleting the unsafe environment concatenation.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (not applicable; internal bug fix)
- [ ] CHANGELOG.md updated (not applicable; no deprecation or breaking change)
- [ ] Appropriate labels applied (maintainers can apply `bug` if desired)

## Reviewer Notes

The analogous `StaticAnalysisToolExecutableFinder` still mutates `PATH`. It is intentionally left out so this change stays scoped to issue #3423.

Local verification:

- `make cs`
- PHPStan, Mago, Composer validation, Rector, collision detection, and ADR-list checks passed
- autoreview suite: 1,762 tests / 1,722 assertions
- default unit suite: 4,837 tests / 13,347 assertions; 4 environment-dependent skips
- integration suite: 1,950 tests / 3,188 assertions; 10 environment/platform-dependent skips
- targeted finder tests: 20 tests / 42 assertions
- changed-line Infection run: 47/47 mutants killed, 100% mutation code coverage and 100% covered-code MSI
- native zizmor 1.29.0: no findings

## Related issues

Fixes https://github.com/infection/infection/issues/3423.
