### PR TITLE
test(test-framework): Add a PHPStan rule to capture deprecrated usages

### DIFF
--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -1084,6 +1084,12 @@ parameters:
 			path: ../src/Testing/SingletonContainer.php
 
 		-
+			rawMessage: Infection\Testing\TestFramework\Debug\DebugTestFrameworkAdapter should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Testing/TestFramework/Debug/DebugTestFrameworkAdapter.php
+
+		-
 			rawMessage: Infection\Tests\AutoReview\ConcreteClassReflector should not exist
 			identifier: phpat.testConcretePHPUnitTestSupportClassesHaveTests
 			count: 1

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -148,6 +148,12 @@ parameters:
 			path: ../src/Container/Container.php
 
 		-
+			rawMessage: Infection\Container\Container should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 3
+			path: ../src/Container/Container.php
+
+		-
 			rawMessage: '''
 				Instantiation of deprecated class Infection\TestFramework\LegacyTestFrameworkBridge:
 				This is for the compatibility layer with the old AbstractTestFramework contract. To be removed.
@@ -265,10 +271,28 @@ parameters:
 			path: ../src/Logger/ArtefactCollection/ConsoleNoProgressLogger.php
 
 		-
+			rawMessage: Infection\Logger\ArtefactCollection\ConsoleNoProgressLogger should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Logger/ArtefactCollection/ConsoleNoProgressLogger.php
+
+		-
 			rawMessage: Dead catch - InvalidArgumentException is never thrown in the try block.
 			identifier: catch.neverThrown
 			count: 1
 			path: ../src/Logger/ArtefactCollection/ConsoleProgressBarLogger.php
+
+		-
+			rawMessage: Infection\Logger\ArtefactCollection\ConsoleProgressBarLogger should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Logger/ArtefactCollection/ConsoleProgressBarLogger.php
+
+		-
+			rawMessage: Infection\Logger\ArtefactCollection\InitialTestsExecution\InitialTestsExecutionLoggerFactory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Logger/ArtefactCollection/InitialTestsExecution/InitialTestsExecutionLoggerFactory.php
 
 		-
 			rawMessage: 'Parameter #1 $level (string) of method Infection\Logger\Console\ConsoleLogger::log() should be contravariant with parameter $level (mixed) of method Psr\Log\AbstractLogger::log()'
@@ -341,6 +365,12 @@ parameters:
 			identifier: phpat.testConcreteSourceClassesHaveTests
 			count: 1
 			path: ../src/Mutant/MutantExecutionResult.php
+
+		-
+			rawMessage: Infection\Mutant\TestFrameworkMutantExecutionResultFactory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Mutant/TestFrameworkMutantExecutionResultFactory.php
 
 		-
 			rawMessage: Do not use magic number as a function argument. Move to constant with a suitable name.
@@ -487,10 +517,28 @@ parameters:
 			path: ../src/PhpParser/Visitor/ReflectionVisitor.php
 
 		-
+			rawMessage: Infection\Process\Factory\InitialTestsRunProcessFactory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Process/Factory/InitialTestsRunProcessFactory.php
+
+		-
+			rawMessage: Infection\Process\Factory\MutantProcessContainerFactory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Process/Factory/MutantProcessContainerFactory.php
+
+		-
 			rawMessage: 'Parameter #2 $env (array<bool|string>|null) of method Infection\Process\OriginalPhpProcess::start() should be contravariant with parameter $env (array) of method Symfony\Component\Process\Process::start()'
 			identifier: method.childParameterType
 			count: 1
 			path: ../src/Process/OriginalPhpProcess.php
+
+		-
+			rawMessage: Infection\Process\Runner\InitialTestsFailed should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Process/Runner/InitialTestsFailed.php
 
 		-
 			rawMessage: 'Method Infection\Reflection\AnonymousClassReflection::__construct() has parameter $reflectionClass with generic class ReflectionClass but does not specify its types: T'
@@ -715,6 +763,12 @@ parameters:
 			path: ../src/StaticAnalysis/StaticAnalysisToolAdapterFactory.php
 
 		-
+			rawMessage: Infection\TestFramework\AbstractTestFrameworkAdapter should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/AbstractTestFrameworkAdapter.php
+
+		-
 			rawMessage: 'Parameter #2 $paths of method Composer\Autoload\ClassLoader::setPsr4() expects list<string>|string, array<string> given.'
 			identifier: argument.type
 			count: 1
@@ -775,6 +829,12 @@ parameters:
 			path: ../src/TestFramework/Coverage/CoverageChecker.php
 
 		-
+			rawMessage: Infection\TestFramework\Coverage\JUnit\JUnitTestExecutionInfoAdder should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/Coverage/JUnit/JUnitTestExecutionInfoAdder.php
+
+		-
 			rawMessage: Infection\TestFramework\Coverage\Locator\Throwable\InvalidReportSource should not exist
 			identifier: phpat.testConcreteSourceClassesHaveTests
 			count: 1
@@ -797,6 +857,24 @@ parameters:
 			identifier: arrayFilter.strict
 			count: 1
 			path: ../src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php
+
+		-
+			rawMessage: Infection\TestFramework\Factory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/Factory.php
+
+		-
+			rawMessage: Infection\TestFramework\Factory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapterFactory
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/Factory.php
+
+		-
+			rawMessage: Infection\TestFramework\LegacyTestFrameworkBridge should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/LegacyTestFrameworkBridge.php
 
 		-
 			rawMessage: Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter should not depend on Infection\Config\ValueProvider\PCOVDirectoryProvider
@@ -833,6 +911,18 @@ parameters:
 			identifier: phpat.testPHPUnitAdapterStaysWithinFuturePackageBoundary
 			count: 1
 			path: ../src/TestFramework/PhpUnit/Adapter/PhpUnitAdapter.php
+
+		-
+			rawMessage: Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+
+		-
+			rawMessage: Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory should not depend on Infection\AbstractTestFramework\TestFrameworkAdapterFactory
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
 
 		-
 			rawMessage: Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapterFactory should not depend on Infection\Config\ValueProvider\PCOVDirectoryProvider
@@ -943,6 +1033,12 @@ parameters:
 			path: ../src/TestFramework/PhpUnit/Config/XmlConfigurationVersionProvider.php
 
 		-
+			rawMessage: Infection\TestFramework\TestFrameworkTypes should not depend on Infection\AbstractTestFramework\TestFrameworkAdapterFactory
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/TestFramework/TestFrameworkTypes.php
+
+		-
 			rawMessage: Do not use magic number in arithmetic operations. Move to constant with a suitable name.
 			count: 1
 			path: ../src/TestFramework/Tracing/TestLocationBucketSorter.php
@@ -992,6 +1088,12 @@ parameters:
 			identifier: phpat.testConcreteSourceClassesHaveTests
 			count: 1
 			path: ../src/Testing/SingletonContainer.php
+
+		-
+			rawMessage: Infection\Testing\TestFramework\Debug\DebugTestFrameworkAdapter should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
+			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
+			count: 1
+			path: ../src/Testing/TestFramework/Debug/DebugTestFrameworkAdapter.php
 
 		-
 			rawMessage: '''

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -871,12 +871,6 @@ parameters:
 			path: ../src/TestFramework/Factory.php
 
 		-
-			rawMessage: Infection\TestFramework\LegacyTestFrameworkBridge should not depend on Infection\AbstractTestFramework\TestFrameworkAdapter
-			identifier: phpat.testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory
-			count: 1
-			path: ../src/TestFramework/LegacyTestFrameworkBridge.php
-
-		-
 			rawMessage: Infection\TestFramework\PhpUnit\Adapter\PhpUnitAdapter should not depend on Infection\Config\ValueProvider\PCOVDirectoryProvider
 			identifier: phpat.testPHPUnitAdapterStaysWithinFuturePackageBoundary
 			count: 1

--- a/devTools/phpstan.neon
+++ b/devTools/phpstan.neon
@@ -71,6 +71,10 @@ services:
         tags:
             - phpat.test
     -
+        class: Infection\Tests\Architecture\PHPat\LegacyTestFrameworkAdaptersShouldNotBeUsedTest
+        tags:
+            - phpat.test
+    -
         class: Infection\Tests\Architecture\PHPat\StaticOrConstOnlyClassesShouldNotBeInstantiableTest
         tags:
             - phpat.test

--- a/tests/Architecture/PHPat/LegacyTestFrameworkAdaptersShouldNotBeUsedTest.php
+++ b/tests/Architecture/PHPat/LegacyTestFrameworkAdaptersShouldNotBeUsedTest.php
@@ -49,7 +49,10 @@ final class LegacyTestFrameworkAdaptersShouldNotBeUsedTest
     {
         return PHPat::rule()
             ->classes(InfectionSelector::sourceCode())
-            ->excluding(Selector::withFilepath('#/src/TestFramework/PhpUnit/Legacy/#', true))
+            ->excluding(
+                Selector::withFilepath('#/src/TestFramework/LegacyTestFrameworkBridge\.php$#', true),
+                Selector::withFilepath('#/src/TestFramework/PhpUnit/Legacy/#', true),
+            )
             ->shouldNot()
             ->dependOn()
             ->classes(

--- a/tests/Architecture/PHPat/LegacyTestFrameworkAdaptersShouldNotBeUsedTest.php
+++ b/tests/Architecture/PHPat/LegacyTestFrameworkAdaptersShouldNotBeUsedTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\Architecture\PHPat;
+
+use Infection\AbstractTestFramework\TestFrameworkAdapter;
+use Infection\AbstractTestFramework\TestFrameworkAdapterFactory;
+use Infection\Tests\Architecture\PHPat\Selector\ClassNamedAny;
+use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
+use PHPat\Selector\Selector;
+use PHPat\Test\Builder\Rule;
+use PHPat\Test\PHPat;
+
+final class LegacyTestFrameworkAdaptersShouldNotBeUsedTest
+{
+    public function testLegacyTestFrameworkAdaptersAreOnlyUsedInTheLegacyDirectory(): Rule
+    {
+        return PHPat::rule()
+            ->classes(InfectionSelector::sourceCode())
+            ->excluding(Selector::withFilepath('#/src/TestFramework/PhpUnit/Legacy/#', true))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(
+                new ClassNamedAny([
+                    TestFrameworkAdapter::class,
+                    TestFrameworkAdapterFactory::class,
+                ]))
+            ->because('TestFrameworkAdapter and TestFrameworkAdapterFactory are deprecated outside the PHPUnit legacy compatibility layer.');
+    }
+}


### PR DESCRIPTION
## Description

Follow up of my comment in https://github.com/infection/infection/pull/3525.

This PR adds a PHPat rule to have a violation for code using `TestFrameworkAdapter` and `TestFrameworkAdapterFactory`. Normally, we could have those violations by adding `@deprecated` to them, but since they are in a separate package we cannot do that here.

This PR also adds the directory `src/TestFramework/PhpUnit/Legacy/` where code using `TestFrameworkAdapter` and `TestFrameworkAdapterFactory` will not trigger a deprecation. Indeed, whilst we will migrate code to use the new API, a lot of old code will need to stay for a while, e.g. `JUnitTestExecutionInfoAdder`.

## Related issues

- #2863