### PR TITLE
chore(sbx): Add PCOV to the Docker Sandbox

### DIFF
--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -26,7 +26,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         php${PHP_VERSION}-mbstring \
         php${PHP_VERSION}-xml \
         php${PHP_VERSION}-zip \
-        # Coverage driver
+        # Coverage drivers
+        php${PHP_VERSION}-pcov \
         php${PHP_VERSION}-xdebug \
         # Build tools required by PIE to install PHP extensions that compile locally
         autoconf \
@@ -53,8 +54,7 @@ COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
 RUN set -o errexit -o nounset -o pipefail \
     && curl -fL --output /tmp/pie.phar https://github.com/php/pie/releases/latest/download/pie.phar \
     && mv /tmp/pie.phar /usr/local/bin/pie \
-    && chmod +x /usr/local/bin/pie \
-    && pie install pecl/pcov --no-interaction
+    && chmod +x /usr/local/bin/pie
 
 ARG CONTAINER_STRUCTURE_TEST_VERSION=1.22.1
 ARG TARGET_ARCH

--- a/devTools/sbx/Dockerfile
+++ b/devTools/sbx/Dockerfile
@@ -53,7 +53,8 @@ COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
 RUN set -o errexit -o nounset -o pipefail \
     && curl -fL --output /tmp/pie.phar https://github.com/php/pie/releases/latest/download/pie.phar \
     && mv /tmp/pie.phar /usr/local/bin/pie \
-    && chmod +x /usr/local/bin/pie
+    && chmod +x /usr/local/bin/pie \
+    && pie install pecl/pcov --no-interaction
 
 ARG CONTAINER_STRUCTURE_TEST_VERSION=1.22.1
 ARG TARGET_ARCH

--- a/devTools/sbx/test.yaml
+++ b/devTools/sbx/test.yaml
@@ -14,6 +14,11 @@ commandTests:
         expectedOutput: ['(?m)^xdebug\.mode => coverage => coverage$']
         exitCode: 0
 
+    -   name: "PCOV is installed"
+        command: "php"
+        args: ["-r", "exit(extension_loaded('pcov') ? 0 : 1);"]
+        exitCode: 0
+
     -   name: "PHP memory limit is disabled"
         command: "php"
         args: ["-r", "echo ini_get('memory_limit'), PHP_EOL;"]


### PR DESCRIPTION
It is useful to have to be able to execute some end-to-end tests from within the sandbox.