### PR TITLE
chore(docker): Add the missing docker commands to the Makefile

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Contributions are always welcome. Here are a few guidelines to be aware of:
 
 ## Tests
 
-To run the tests locally, you can run `make test`. It, however, requires [Docker][docker]. For more
-granular tests, you can run `make` to see the available commands.
+To run the tests locally, you can run `make test`, or, `make test-docker` to execute the command with [Docker][docker].
+Execute `make` to see the available commands. Most commands have a `-docker` variant.
 
 ### PhpParser visitor tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,6 @@ make help                 # the definitive list of targets
 make cs                   # PHP-CS-Fixer; ALWAYS this, never hand-format
 make autoreview           # cs-check + PHPStan(+PHPat) + Mago + composer validate
                           #   + AutoReview suite + Rector dry-run + collision detector
-                          #   + zizmor (locally only; CI skips it here)
 make test-unit            # default group, e2e excluded
 make test-unit-parallel   # paratest WrapperRunner
 make test-e2e             # PHPUnit-group e2e + scripted scenarios

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ make help                 # the definitive list of targets
 make cs                   # PHP-CS-Fixer; ALWAYS this, never hand-format
 make autoreview           # cs-check + PHPStan(+PHPat) + Mago + composer validate
                           #   + AutoReview suite + Rector dry-run + collision detector
+                          #   + zizmor (locally only; CI skips it here)
 make test-unit            # default group, e2e excluded
 make test-unit-parallel   # paratest WrapperRunner
 make test-e2e             # PHPUnit-group e2e + scripted scenarios

--- a/Makefile
+++ b/Makefile
@@ -259,12 +259,17 @@ benchmark_tracing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COV
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions check-agents-adr-list
+autoreview: _autoreview $(if $(CI),,zizmor)
+
+.PHONY: _autoreview
+_autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions check-agents-adr-list
 
 .PHONY: autoreview-docker
 autoreview-docker:	## Runs various checks in docker (static analysis & AutoReview test suite)
 autoreview-docker: $(DOCKER_FILE_IMAGE)
-	$(DOCKER_RUN_83) make autoreview
+	$(DOCKER_RUN_83) make _autoreview
+	# Zizmor is already executed via a docker image.
+	$(MAKE) zizmor
 
 .PHONY: test
 test:		 	## Runs all the tests

--- a/Makefile
+++ b/Makefile
@@ -129,10 +129,8 @@ cs: $(PHP_CS_FIXER)
 
 .PHONY: cs-docker
 cs-docker:		## Runs PHP-CS-Fixer in docker
-cs-docker: $(DOCKER_FILE_IMAGE) $(PHP_CS_FIXER)
-	$(DOCKER_RUN_83) $(PHP_CS_FIXER) fix -v --diff
-	LC_ALL=C sort -u .gitignore -o .gitignore
-	$(MAKE) check_trailing_whitespaces
+cs-docker: $(DOCKER_FILE_IMAGE)
+	$(DOCKER_RUN_83) make cs
 
 .PHONY: cs-check
 cs-check:		## Runs PHP-CS-Fixer in dry-run mode
@@ -261,7 +259,12 @@ benchmark_tracing: vendor $(BENCHMARK_TRACING_SUBMODULE) $(BENCHMARK_TRACING_COV
 
 .PHONY: autoreview
 autoreview: 	 	## Runs various checks (static analysis & AutoReview test suite)
-autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions check-agents-adr-list $(if $(CI),,zizmor)
+autoreview: cs-check phpstan mago validate test-autoreview rector-check detect-collisions check-agents-adr-list
+
+.PHONY: autoreview-docker
+autoreview-docker:	## Runs various checks in docker (static analysis & AutoReview test suite)
+autoreview-docker: $(DOCKER_FILE_IMAGE)
+	$(DOCKER_RUN_83) make autoreview
 
 .PHONY: test
 test:		 	## Runs all the tests
@@ -269,7 +272,7 @@ test: autoreview test-unit test-benchmark test-e2e test-infection
 
 .PHONY: test-docker
 test-docker:		## Runs all the tests on the different Docker platforms
-test-docker: autoreview test-unit-docker test-e2e-docker test-infection-docker
+test-docker: autoreview-docker test-unit-docker test-e2e-docker test-infection-docker
 
 .PHONY: test-autoreview
 test-autoreview: $(PHPUNIT_BIN) vendor
@@ -287,10 +290,8 @@ test-unit-parallel: $(PARATEST) vendor
 
 .PHONY: test-unit-docker
 test-unit-docker:	## Runs the unit tests on the different Docker platforms
-test-unit-docker: test-unit-83-docker
-
-test-unit-83-docker: $(DOCKER_FILE_IMAGE) $(PHPUNIT_BIN)
-	$(DOCKER_RUN_83) $(PHPUNIT) --group $(PHPUNIT_GROUP)
+test-unit-docker: $(DOCKER_FILE_IMAGE)
+	$(DOCKER_RUN_83) make test-unit
 
 .PHONY: test-benchmark
 test-benchmark:	 	## Runs the benchmark tests

--- a/tests/phpunit/AutoReview/Makefile/MakefileTest.php
+++ b/tests/phpunit/AutoReview/Makefile/MakefileTest.php
@@ -202,7 +202,7 @@ final class MakefileTest extends BaseMakefileTestCase
             }
 
             if ($target === 'test-docker') {
-                array_unshift($subTestTargets, 'autoreview');
+                array_unshift($subTestTargets, 'autoreview-docker');
             }
 
             $this->assertSame(
@@ -239,7 +239,7 @@ final class MakefileTest extends BaseMakefileTestCase
         $testPrerequisites = array_shift($testRules)->getPrerequisites();
 
         $rootTestTargets = self::getRootTestTargets($testRules, 2);
-        array_unshift($rootTestTargets, 'autoreview');
+        array_unshift($rootTestTargets, 'autoreview-docker');
 
         $this->assertEqualsCanonicalizing($rootTestTargets, $testPrerequisites);
     }
@@ -275,6 +275,7 @@ final class MakefileTest extends BaseMakefileTestCase
             [33mzizmor:[0m			 Runs zizmor
             [33mprofile:[0m 	 	 Runs Blackfire
             [33mautoreview:[0m 	 	 Runs various checks (static analysis & AutoReview test suite)
+            [33mautoreview-docker:[0m	 Runs various checks in docker (static analysis & AutoReview test suite)
             [33mtest:[0m		 	 Runs all the tests
             [33mtest-docker:[0m		 Runs all the tests on the different Docker platforms
             [33mtest-unit:[0m	 	 Runs the unit tests


### PR DESCRIPTION
In https://github.com/infection/infection/pull/2074, it was noticed that a few commands were missing the Docker variant which meant all checks could not be done with docker only. This PR addresses those points:

- Make `cs-docker` now runs the canonical make cs target inside PHP 8.3 Docker, no more commands are executed outside of Docker.
- Add the missing `autoreview-docker` command.
- `test-docker` now depends on `autoreview-docker` instead of `autoreview`.
- `test-unit-docker` now runs the canonical `make test-unit` command inside PHP 8.3 Docker. This should not be an actual change in behaviour but avoids duplicating the PHPUnit command.