### PR TITLE
cs: Add a Rector rule to enforce `@param` over `@var`

### DIFF
--- a/mago.toml
+++ b/mago.toml
@@ -32,6 +32,7 @@ excludes = [
     "tests/phpunit/PhpParser/Visitor/EnrichmentTraverse/Fixtures",
     # Rector or PHPStan stubs can pollute Mago's Reflection inference
     # https://github.com/carthage-software/mago/issues/1676
+    "tests/phpunit/AutoReview/Rector",
     "vendor/rector/rector",
     "vendor/phpstan",
 ]

--- a/rector.php
+++ b/rector.php
@@ -33,6 +33,7 @@
 
 declare(strict_types=1);
 
+use Infection\Tests\AutoReview\Rector\VarTagOnParameterToParamTagRector;
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector\BooleanNot\NegatedAndsToPositiveOrsRector;
 use Rector\CodeQuality\Rector\BooleanNot\SimplifyDeMorganBinaryRector;
@@ -125,6 +126,7 @@ $config = RectorConfig::configure()
         PrivatizeFinalClassMethodRector::class,
         PrivatizeFinalClassPropertyRector::class,
         TypedPropertyFromAssignsRector::class,
+        VarTagOnParameterToParamTagRector::class,
     ])
     ->withConfiguredRule(
         ClassPropertyAssignToConstructorPromotionRector::class,

--- a/src/Configuration/ClassifiedPaths.php
+++ b/src/Configuration/ClassifiedPaths.php
@@ -43,10 +43,12 @@ namespace Infection\Configuration;
  */
 final readonly class ClassifiedPaths
 {
+    /**
+     * @param list<non-empty-string> $sourcePaths
+     * @param list<non-empty-string> $testPaths
+     */
     public function __construct(
-        /** @var list<non-empty-string> */
         public array $sourcePaths,
-        /** @var list<non-empty-string> */
         public array $testPaths,
     ) {
     }

--- a/src/Process/Factory/MutantProcessContainerFactory.php
+++ b/src/Process/Factory/MutantProcessContainerFactory.php
@@ -56,13 +56,13 @@ class MutantProcessContainerFactory
 
     private const int TEST_FRAMEWORK_BOOTSTRAP_THRESHOLD = 5;
 
+    /**
+     * @param list<LazyMutantProcessFactory> $lazyMutantProcessCreators
+     */
     public function __construct(
         private readonly TestFrameworkAdapter $testFrameworkAdapter,
         private readonly float $timeout,
         private readonly MutantExecutionResultFactory $mutantExecutionResultFactory,
-        /**
-         * @var list<LazyMutantProcessFactory>
-         */
         private readonly array $lazyMutantProcessCreators,
         private readonly Configuration $configuration,
     ) {

--- a/src/Process/MutantProcessContainer.php
+++ b/src/Process/MutantProcessContainer.php
@@ -52,11 +52,11 @@ class MutantProcessContainer
 
     private int $currentProcessIndex = 0;
 
+    /**
+     * @param list<LazyMutantProcessFactory> $lazyMutantProcessCreators
+     */
     public function __construct(
         MutantProcess $phpUnitMutantProcess,
-        /**
-         * @var list<LazyMutantProcessFactory>
-         */
         private readonly array $lazyMutantProcessCreators,
     ) {
         $this->processes[] = $phpUnitMutantProcess;

--- a/tests/Architecture/PHPat/Selector/Support/Analyser/AnalysisResult.php
+++ b/tests/Architecture/PHPat/Selector/Support/Analyser/AnalysisResult.php
@@ -37,6 +37,9 @@ namespace Infection\Tests\Architecture\PHPat\Selector\Support\Analyser;
 
 final readonly class AnalysisResult
 {
+    /**
+     * @param list<string> $environmentVariables
+     */
     public function __construct(
         public bool $hasTrivialImplementation,
         public bool $usesIo,
@@ -44,7 +47,6 @@ final readonly class AnalysisResult
         public bool $hasCoversNothing,
         public bool $belongsToIntegrationGroup,
         public bool $declaresPublicNonReadonlyProperty,
-        /** @var list<string> */
         public array $environmentVariables,
     ) {
     }

--- a/tests/phpunit/AutoReview/Rector/Fixture/var_tag_on_parameter.php.inc
+++ b/tests/phpunit/AutoReview/Rector/Fixture/var_tag_on_parameter.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+final class Paths
+{
+    public function __construct(
+        /** @var list<string> Source paths. */
+        public array $sourcePaths,
+        /** @var list<string> */
+        public array $testPaths,
+    ) {
+    }
+
+    /** @param non-empty-string $path Existing type. */
+    public function add(
+        /** @var string This must not replace the existing type. */
+        string $path,
+    ): void {
+    }
+}
+
+?>
+-----
+<?php
+
+final class Paths
+{
+    /**
+     * @param list<string> $sourcePaths Source paths.
+     * @param list<string> $testPaths
+     */
+    public function __construct(
+        public array $sourcePaths,
+        public array $testPaths,
+    ) {
+    }
+
+    /** @param non-empty-string $path Existing type. */
+    public function add(
+        string $path,
+    ): void {
+    }
+}
+
+?>

--- a/tests/phpunit/AutoReview/Rector/VarTagOnParameterToParamTagRector.php
+++ b/tests/phpunit/AutoReview/Rector/VarTagOnParameterToParamTagRector.php
@@ -43,8 +43,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Comments\NodeDocBlock\DocBlockUpdater;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
-use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class VarTagOnParameterToParamTagRector extends AbstractRector
 {
@@ -52,40 +50,6 @@ final class VarTagOnParameterToParamTagRector extends AbstractRector
         private readonly PhpDocInfoFactory $phpDocInfoFactory,
         private readonly DocBlockUpdater $docBlockUpdater,
     ) {
-    }
-
-    #[Override]
-    public function getRuleDefinition(): RuleDefinition
-    {
-        return new RuleDefinition(
-            'Move a parameter @var annotation to the method PHPDoc as @param',
-            [
-                new CodeSample(
-                    <<<'CODE_SAMPLE'
-                        final class Paths
-                        {
-                            public function __construct(
-                                /** @var list<string> */
-                                public array $paths,
-                            ) {
-                            }
-                        }
-                        CODE_SAMPLE,
-                    <<<'CODE_SAMPLE'
-                        final class Paths
-                        {
-                            /**
-                             * @param list<string> $paths
-                             */
-                            public function __construct(
-                                public array $paths,
-                            ) {
-                            }
-                        }
-                        CODE_SAMPLE,
-                ),
-            ],
-        );
     }
 
     /**

--- a/tests/phpunit/AutoReview/Rector/VarTagOnParameterToParamTagRector.php
+++ b/tests/phpunit/AutoReview/Rector/VarTagOnParameterToParamTagRector.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * This code is licensed under the BSD 3-Clause License.
+ *
+ * Copyright (c) 2017, Maks Rafalko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+declare(strict_types=1);
+
+namespace Infection\Tests\AutoReview\Rector;
+
+use Override;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class VarTagOnParameterToParamTagRector extends AbstractRector
+{
+    public function __construct(
+        private readonly PhpDocInfoFactory $phpDocInfoFactory,
+        private readonly DocBlockUpdater $docBlockUpdater,
+    ) {
+    }
+
+    #[Override]
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Move a parameter @var annotation to the method PHPDoc as @param',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        final class Paths
+                        {
+                            public function __construct(
+                                /** @var list<string> */
+                                public array $paths,
+                            ) {
+                            }
+                        }
+                        CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                        final class Paths
+                        {
+                            /**
+                             * @param list<string> $paths
+                             */
+                            public function __construct(
+                                public array $paths,
+                            ) {
+                            }
+                        }
+                        CODE_SAMPLE,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    #[Override]
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    #[Override]
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof ClassMethod) {
+            return null;
+        }
+
+        $methodPhpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
+        $hasChanged = false;
+
+        foreach ($node->params as $param) {
+            $paramPhpDocInfo = $this->phpDocInfoFactory->createFromNode($param);
+
+            if ($paramPhpDocInfo === null) {
+                continue;
+            }
+
+            $varTag = $paramPhpDocInfo->getVarTagValueNode();
+
+            if (!$varTag instanceof VarTagValueNode) {
+                continue;
+            }
+
+            $parameterName = $this->getName($param);
+
+            if ($parameterName === null) {
+                continue;
+            }
+
+            if ($methodPhpDocInfo->getParamTagValueByName($parameterName) === null) {
+                $methodPhpDocInfo->addTagValueNode(new ParamTagValueNode(
+                    clone $varTag->type,
+                    $param->variadic,
+                    '$' . $parameterName,
+                    $varTag->description,
+                    $param->byRef,
+                ));
+            }
+
+            $paramPhpDocInfo->removeByType(VarTagValueNode::class);
+            $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($param);
+            $hasChanged = true;
+        }
+
+        if (!$hasChanged) {
+            return null;
+        }
+
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+
+        return $node;
+    }
+}

--- a/tests/phpunit/AutoReview/Rector/VarTagOnParameterToParamTagRectorTest.php
+++ b/tests/phpunit/AutoReview/Rector/VarTagOnParameterToParamTagRectorTest.php
@@ -33,44 +33,31 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage\Locator\Throwable;
+namespace Infection\Tests\AutoReview\Rector;
 
-use function implode;
-use RuntimeException;
-use function sprintf;
-use Throwable;
+use Iterator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
-/**
- * @internal
- */
-final class TooManyReportsFound extends RuntimeException implements ReportLocationThrowable
+#[CoversClass(VarTagOnParameterToParamTagRector::class)]
+#[Group('integration')]
+final class VarTagOnParameterToParamTagRectorTest extends AbstractRectorTestCase
 {
-    /**
-     * @param list<string>|null $reportPathnames
-     */
-    public function __construct(
-        string $message = '',
-        int $code = 0,
-        ?Throwable $previous = null,
-        public readonly ?array $reportPathnames = null,
-    ) {
-        parent::__construct($message, $code, $previous);
+    #[DataProvider('provideFixtures')]
+    public function test_it_moves_var_tags_to_the_method(string $fixture): void
+    {
+        $this->doTestFile($fixture);
     }
 
-    /**
-     * @param list<string> $reportPathnames
-     */
-    public static function create(array $reportPathnames): self
+    public static function provideFixtures(): Iterator
     {
-        return new self(
-            sprintf(
-                'Found "%s".',
-                implode(
-                    '", "',
-                    $reportPathnames,
-                ),
-            ),
-            reportPathnames: $reportPathnames,
-        );
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/tests/phpunit/AutoReview/Rector/config/configured_rule.php
+++ b/tests/phpunit/AutoReview/Rector/config/configured_rule.php
@@ -33,44 +33,8 @@
 
 declare(strict_types=1);
 
-namespace Infection\TestFramework\Coverage\Locator\Throwable;
+use Infection\Tests\AutoReview\Rector\VarTagOnParameterToParamTagRector;
+use Rector\Config\RectorConfig;
 
-use function implode;
-use RuntimeException;
-use function sprintf;
-use Throwable;
-
-/**
- * @internal
- */
-final class TooManyReportsFound extends RuntimeException implements ReportLocationThrowable
-{
-    /**
-     * @param list<string>|null $reportPathnames
-     */
-    public function __construct(
-        string $message = '',
-        int $code = 0,
-        ?Throwable $previous = null,
-        public readonly ?array $reportPathnames = null,
-    ) {
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @param list<string> $reportPathnames
-     */
-    public static function create(array $reportPathnames): self
-    {
-        return new self(
-            sprintf(
-                'Found "%s".',
-                implode(
-                    '", "',
-                    $reportPathnames,
-                ),
-            ),
-            reportPathnames: $reportPathnames,
-        );
-    }
-}
+return RectorConfig::configure()
+    ->withRules([VarTagOnParameterToParamTagRector::class]);


### PR DESCRIPTION
In PHP we now have the choice between:

```php
    public function __construct(
        /** @var list<string> Source paths. */
        public array $sourcePaths,
        /** @var list<string> */
        public array $testPaths,
    ) {
    }
```

And:

```php
    /**
     * @param list<string> $sourcePaths Source paths.
     * @param list<string> $testPaths
     */
    public function __construct(
        public array $sourcePaths,
        public array $testPaths,
    ) {
    }
```

I tend to prefer the latter simply because it means keeping one style does not mean to update all existing code. To try to solve this in an automatic way, this PR introduces a Rector rule.

That being said, I do not feel strongly about which form is preferred, I would simply like _one_ form and have a tool to automatically enforce it.

I did not bother creating an ADR because I don't think it is a worthwhile issue to capture in it.
