### PR TITLE
chore: Replace direct file access with FileSystem abstraction

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -627,7 +627,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php"
 code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php:91:16}`."
+message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php:92:16}`."
 count = 1
 
 [[issues]]
@@ -687,7 +687,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/TestFrameworkConfigPathProvider.php:106:16}`."
+message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/TestFrameworkConfigPathProvider.php:107:16}`."
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -61,15 +61,15 @@ message = 'Potentially unhandled exception `RuntimeException` in `Infection\Comm
 count = 1
 
 [[issues]]
-file = "src/Command/ConfigureCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\ConfigureCommand::saveConfig`.'
+file = "src/Command/Debug/DumpAstCommand.php"
+code = "mixed-operand"
+message = "Casting `mixed` to `bool`."
 count = 1
 
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
-code = "mixed-operand"
-message = "Casting `mixed` to `bool`."
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Command\Debug\DumpAstCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -94,12 +94,6 @@ count = 1
 file = "src/Command/Debug/MockTeamCityCommand.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/MockTeamCityCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\Debug\MockTeamCityCommand::getLogLines`.'
 count = 1
 
 [[issues]]
@@ -153,7 +147,31 @@ count = 1
 [[issues]]
 file = "src/Command/Git/GitChangedFilesCommand.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\Git\GitChangedFilesCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/Git/GitChangedFilesCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedFilesCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/Git/GitChangedFilesCommand.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedFilesCommand::getFiles`.'
+count = 1
+
+[[issues]]
+file = "src/Command/Git/GitChangedLinesCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\Git\GitChangedLinesCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/Git/GitChangedLinesCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedLinesCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -178,6 +196,24 @@ count = 1
 file = "src/Command/Git/Option/FilterOption.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
+count = 1
+
+[[issues]]
+file = "src/Command/InitialTest/InitialTestRunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/InitialTest/InitialTestRunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/InitialTest/InitialTestRunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -238,12 +274,6 @@ count = 1
 file = "src/Command/MakeCustomMutatorCommand.php"
 code = "unhandled-thrown-type"
 message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Command/MakeCustomMutatorCommand.php:107:33}`."
-count = 1
-
-[[issues]]
-file = "src/Command/MakeCustomMutatorCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\MakeCustomMutatorCommand::createProjectFilesFromTemplates`.'
 count = 1
 
 [[issues]]
@@ -375,6 +405,24 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\RunCommand::installTestFrameworkIfNeeded`.'
 count = 1
 
@@ -387,13 +435,43 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\ExceptionInterface` in `Infection\Command\RunCommand::runConfigurationCommand`.'
 count = 1
 
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\RunCommand::startUp`.'
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Command\RunCommand::executeCommand`.'
+count = 1
+
+[[issues]]
+file = "src/Command/RunCommand.php"
+code = "unhandled-thrown-type"
+message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Command\RunCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -585,7 +663,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/TestFrameworkConfigPathProvider.php:108:16}`."
+message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/TestFrameworkConfigPathProvider.php:105:16}`."
 count = 1
 
 [[issues]]
@@ -1417,12 +1495,6 @@ message = 'Potentially unhandled exception `ReflectionException` in `Infection\E
 count = 1
 
 [[issues]]
-file = "src/Event/Subscriber/CleanUpAfterMutationTestingFinishedSubscriber.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Event\Subscriber\CleanUpAfterMutationTestingFinishedSubscriber::onMutationTestingWasFinished`.'
-count = 1
-
-[[issues]]
 file = "src/FileSystem/FakeFileSystem.php"
 code = "imprecise-type"
 message = "Type `iterable` in parameter `$dirs` is imprecise, equivalent to `iterable<mixed, mixed>`."
@@ -1894,12 +1966,6 @@ count = 1
 file = "src/Mutation/FileMutationGenerator.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Mutation\FileMutationGenerator::generateMutations`.'
-count = 1
-
-[[issues]]
-file = "src/Mutation/FileMutationGenerator.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Mutation\FileMutationGenerator::generateMutations`.'
 count = 1
 
 [[issues]]
@@ -2737,12 +2803,6 @@ message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\
 count = 1
 
 [[issues]]
-file = "src/Process/Runner/MutationTestingRunner.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Process\Runner\MutationTestingRunner::materializeMutant`.'
-count = 1
-
-[[issues]]
 file = "src/Process/Runner/ParallelProcessRunner.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessStartFailedException` in `Infection\Process\Runner\ParallelProcessRunner::startProcess`.'
@@ -2944,12 +3004,6 @@ count = 1
 file = "src/StaticAnalysis/PHPStan/Mutant/PHPStanMutantExecutionResultFactory.php"
 code = "possibly-null-operand"
 message = "Left operand in `>` comparison might be `null` (type `int|null`)."
-count = 1
-
-[[issues]]
-file = "src/StaticAnalysis/PHPStan/Process/PHPStanMutantProcessFactory.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\StaticAnalysis\PHPStan\Process\PHPStanMutantProcessFactory::buildMutationConfigFile`.'
 count = 1
 
 [[issues]]
@@ -3217,12 +3271,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidX
 count = 1
 
 [[issues]]
-file = "src/TestFramework/Coverage/XmlReport/SourceFileInfoProvider.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\TestFramework\Coverage\XmlReport\SourceFileInfoProvider::provideXPath`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/Coverage/XmlReport/TestLocator.php"
 code = "redundant-docblock-type"
 message = "Redundant docblock type for variable `$methodRange`."
@@ -3238,12 +3286,6 @@ count = 1
 file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
 code = "less-specific-argument"
 message = 'Argument type mismatch for argument #2 of `Infection\TestFramework\Tracing\Trace\TestLocations::__construct`: expected `array<string, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>`, but provided type `array<array-key, Infection\TestFramework\Tracing\Trace\SourceMethodLineRange>` is less specific.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/Coverage/XmlReport/XmlCoverageParser.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\TestFramework\Coverage\XmlReport\XmlCoverageParser::parse`.'
 count = 1
 
 [[issues]]
@@ -3421,12 +3463,6 @@ message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidX
 count = 1
 
 [[issues]]
-file = "src/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\TestFramework\PhpUnit\Config\Builder\InitialConfigBuilder::build`.'
-count = 1
-
-[[issues]]
 file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
 code = "invalid-method-access"
 message = "Attempting to access a method on a non-object type (`false`)."
@@ -3448,12 +3484,6 @@ count = 1
 file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\TestFramework\XML\InvalidXml` in `Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder::getXPath`.'
-count = 1
-
-[[issues]]
-file = "src/TestFramework/PhpUnit/Config/Builder/MutationConfigBuilder.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\TestFramework\PhpUnit\Config\Builder\MutationConfigBuilder::build`.'
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -687,7 +687,7 @@ count = 1
 [[issues]]
 file = "src/Config/ValueProvider/TestFrameworkConfigPathProvider.php"
 code = "unhandled-thrown-type"
-message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/TestFrameworkConfigPathProvider.php:107:16}`."
+message = "Potentially unhandled exception `RuntimeException` in `{closure:src/Config/ValueProvider/TestFrameworkConfigPathProvider.php:108:16}`."
 count = 1
 
 [[issues]]

--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -75,12 +75,6 @@ count = 1
 [[issues]]
 file = "src/Command/Debug/DumpAstCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\NodeDumper\PotentialCircularDependencyDetected` in `Infection\Command\Debug\DumpAstCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Debug/DumpAstCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Command\Debug\DumpAstCommand::createAst`.'
 count = 1
 
@@ -159,31 +153,7 @@ count = 1
 [[issues]]
 file = "src/Command/Git/GitChangedFilesCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\Git\GitChangedFilesCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitChangedFilesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedFilesCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitChangedFilesCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedFilesCommand::getFiles`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitChangedLinesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\Git\GitChangedLinesCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/Git/GitChangedLinesCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\Git\GitChangedLinesCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -208,24 +178,6 @@ count = 1
 file = "src/Command/Git/Option/FilterOption.php"
 code = "mixed-assignment"
 message = "Assigning `mixed` type to a variable may lead to unexpected behavior."
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/InitialTestRunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\FileSystem\Locator\FileOrDirectoryNotFound` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/InitialTestRunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialTestsFailed` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/InitialTest/InitialTestRunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\InitialTest\InitialTestRunCommand::executeCommand`.'
 count = 1
 
 [[issues]]
@@ -423,24 +375,6 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\PhpParser\UnparsableFile` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Process\Runner\InitialStaticAnalysisRunFailed` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Infection\Source\Exception\NoSourceFound` in `Infection\Command\RunCommand::installTestFrameworkIfNeeded`.'
 count = 1
 
@@ -453,30 +387,6 @@ count = 1
 [[issues]]
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\JUnit\TestNotFound` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\NoReportFound` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\ReportLocationThrowable` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Infection\TestFramework\Coverage\Locator\Throwable\TooManyReportsFound` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Console\Exception\ExceptionInterface` in `Infection\Command\RunCommand::runConfigurationCommand`.'
 count = 1
 
@@ -484,18 +394,6 @@ count = 1
 file = "src/Command/RunCommand.php"
 code = "unhandled-thrown-type"
 message = 'Potentially unhandled exception `Symfony\Component\Filesystem\Exception\IOException` in `Infection\Command\RunCommand::startUp`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ExceptionInterface` in `Infection\Command\RunCommand::executeCommand`.'
-count = 1
-
-[[issues]]
-file = "src/Command/RunCommand.php"
-code = "unhandled-thrown-type"
-message = 'Potentially unhandled exception `Symfony\Component\Process\Exception\ProcessTimedOutException` in `Infection\Command\RunCommand::executeCommand`.'
 count = 1
 
 [[issues]]

--- a/mago.toml
+++ b/mago.toml
@@ -63,6 +63,7 @@ unchecked-exceptions = [
     "PHPUnit\\Exception",
     "Psr\\Container\\ContainerExceptionInterface",
     "Safe\\Exceptions\\SafeExceptionInterface",
+    "Symfony\\Component\\Filesystem\\Exception\\ExceptionInterface",
 ]
 ignore = [
     { code = "unhandled-thrown-type", in = ["tests/"] },

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -41,7 +41,6 @@ use Override;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
 use Webmozart\Assert\Assert;
 
 /**
@@ -73,9 +72,6 @@ abstract class BaseCommand extends Command
         $this->io = new IO($input, $output);
     }
 
-    /**
-     * @throws Throwable
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         return $this->executeCommand($this->getIO())
@@ -83,9 +79,6 @@ abstract class BaseCommand extends Command
             : self::FAILURE;
     }
 
-    /**
-     * @throws Throwable
-     */
     abstract protected function executeCommand(IO $io): bool;
 
     final protected function getIO(): IO

--- a/src/Command/BaseCommand.php
+++ b/src/Command/BaseCommand.php
@@ -41,6 +41,7 @@ use Override;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 use Webmozart\Assert\Assert;
 
 /**
@@ -72,6 +73,9 @@ abstract class BaseCommand extends Command
         $this->io = new IO($input, $output);
     }
 
+    /**
+     * @throws Throwable
+     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         return $this->executeCommand($this->getIO())
@@ -79,6 +83,9 @@ abstract class BaseCommand extends Command
             : self::FAILURE;
     }
 
+    /**
+     * @throws Throwable
+     */
     abstract protected function executeCommand(IO $io): bool;
 
     final protected function getIO(): IO

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -66,7 +66,6 @@ use function str_starts_with;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * @internal
@@ -100,9 +99,6 @@ final class ConfigureCommand extends BaseCommand
             );
     }
 
-    /**
-     * @throws IOException
-     */
     protected function executeCommand(IO $io): bool
     {
         if (!$io->isInteractive()) {

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -57,7 +57,6 @@ use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 use OutOfBoundsException;
 use RuntimeException;
-use function Safe\file_get_contents;
 use function Safe\glob;
 use function Safe\json_decode;
 use function Safe\json_encode;
@@ -67,6 +66,7 @@ use function str_starts_with;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * @internal
@@ -100,6 +100,9 @@ final class ConfigureCommand extends BaseCommand
             );
     }
 
+    /**
+     * @throws IOException
+     */
     protected function executeCommand(IO $io): bool
     {
         if (!$io->isInteractive()) {
@@ -128,7 +131,7 @@ final class ConfigureCommand extends BaseCommand
         $questionHelper = $this->getHelper('question');
 
         if ($this->fileSystem->exists('composer.json')) {
-            $content = json_decode(file_get_contents('composer.json'));
+            $content = json_decode($this->fileSystem->readFile('composer.json'));
 
             $sourceDirGuesser = new SourceDirGuesser($content);
         } else {

--- a/src/Command/ConfigureCommand.php
+++ b/src/Command/ConfigureCommand.php
@@ -37,7 +37,6 @@ namespace Infection\Command;
 
 use Composer\InstalledVersions;
 use function count;
-use function file_exists;
 use const GLOB_ONLYDIR;
 use function implode;
 use Infection\Config\ConsoleHelper;
@@ -49,6 +48,7 @@ use Infection\Config\ValueProvider\TestFrameworkConfigPathProvider;
 use Infection\Config\ValueProvider\TextLogFileProvider;
 use Infection\Configuration\Schema\SchemaConfigurationLoader;
 use Infection\Console\IO;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\Framework\InfectionVersion;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
@@ -67,7 +67,6 @@ use function str_starts_with;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -77,6 +76,12 @@ final class ConfigureCommand extends BaseCommand
     public const string NONINTERACTIVE_MODE_ERROR = 'Infection config generator requires an interactive mode.';
 
     private const string OPTION_TEST_FRAMEWORK = 'test-framework';
+
+    public function __construct(
+        private readonly FileSystem $fileSystem = new FileSystem(),
+    ) {
+        parent::__construct();
+    }
 
     protected function configure(): void
     {
@@ -122,7 +127,7 @@ final class ConfigureCommand extends BaseCommand
         /** @var QuestionHelper $questionHelper */
         $questionHelper = $this->getHelper('question');
 
-        if (file_exists('composer.json')) {
+        if ($this->fileSystem->exists('composer.json')) {
             $content = json_decode(file_get_contents('composer.json'));
 
             $sourceDirGuesser = new SourceDirGuesser($content);
@@ -139,13 +144,10 @@ final class ConfigureCommand extends BaseCommand
             $this->abort();
         }
 
-        $container = $this->getApplication()->getContainer();
-        $fileSystem = $container->getFileSystem();
-
         $excludeDirsProvider = new ExcludeDirsProvider(
             $consoleHelper,
             $questionHelper,
-            $fileSystem,
+            $this->fileSystem,
         );
 
         $excludedDirs = $excludeDirsProvider->get($io, $dirsInCurrentDir, $sourceDirs);
@@ -156,6 +158,8 @@ final class ConfigureCommand extends BaseCommand
             $dirsInCurrentDir,
             $io->getInput()->getOption(self::OPTION_TEST_FRAMEWORK),
         );
+
+        $container = $this->getApplication()->getContainer();
 
         $phpUnitExecutableFinder = new TestFrameworkFinder(
             $container->getComposerExecutableFinder(),
@@ -168,7 +172,6 @@ final class ConfigureCommand extends BaseCommand
         $textLogFilePath = $textLogFileProvider->get($io, $dirsInCurrentDir);
 
         $this->saveConfig(
-            $fileSystem,
             $sourceDirs,
             $excludedDirs,
             $phpUnitConfigPath,
@@ -191,7 +194,6 @@ final class ConfigureCommand extends BaseCommand
      * @param string[] $excludedDirs
      */
     private function saveConfig(
-        Filesystem $filesystem,
         array $sourceDirs,
         array $excludedDirs,
         ?string $phpUnitConfigPath = null,
@@ -239,7 +241,7 @@ final class ConfigureCommand extends BaseCommand
             '@default' => true,
         ];
 
-        $filesystem->dumpFile(
+        $this->fileSystem->dumpFile(
             SchemaConfigurationLoader::DEFAULT_JSON5_CONFIG_FILE,
             json_encode($configObject, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
         );
@@ -254,7 +256,7 @@ final class ConfigureCommand extends BaseCommand
     {
         $fileName = 'vendor/infection/infection/resources/schema.json';
 
-        if (file_exists($fileName)) {
+        if ($this->fileSystem->exists($fileName)) {
             return $fileName;
         }
 

--- a/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
+++ b/src/Config/ValueProvider/PhpUnitCustomExecutablePathProvider.php
@@ -37,9 +37,9 @@ namespace Infection\Config\ValueProvider;
 
 use Closure;
 use const DIRECTORY_SEPARATOR;
-use function file_exists;
 use Infection\Config\ConsoleHelper;
 use Infection\Console\IO;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -59,6 +59,7 @@ final readonly class PhpUnitCustomExecutablePathProvider
         private TestFrameworkFinder $phpUnitExecutableFinder,
         private ConsoleHelper $consoleHelper,
         private QuestionHelper $questionHelper,
+        private FileSystem $fileSystem = new FileSystem(),
     ) {
     }
 
@@ -88,10 +89,10 @@ final readonly class PhpUnitCustomExecutablePathProvider
 
     private function getValidator(): Closure
     {
-        return static function ($answerPath): string {
+        return function ($answerPath): string {
             $answerPath = $answerPath !== '' ? trim($answerPath) : $answerPath;
 
-            if ($answerPath === '' || !file_exists($answerPath)) {
+            if ($answerPath === '' || !$this->fileSystem->exists($answerPath)) {
                 throw new RuntimeException(sprintf('Custom path "%s" is incorrect.', $answerPath));
             }
 

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -43,13 +43,12 @@ use Infection\Console\IO;
 use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\TestFrameworkTypes;
-use function is_dir;
 use RuntimeException;
-use function Safe\file_get_contents;
 use function Safe\json_decode;
 use function sprintf;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Filesystem\Exception\IOException;
 use function trim;
 
 /**
@@ -67,6 +66,8 @@ final readonly class TestFrameworkConfigPathProvider
 
     /**
      * @param string[] $dirsInCurrentDir
+     *
+     * @throws IOException
      */
     public function get(IO $io, array $dirsInCurrentDir, string $testFramework): ?string
     {
@@ -83,7 +84,7 @@ final readonly class TestFrameworkConfigPathProvider
                 return $this->askTestFrameworkConfigLocation($io, $dirsInCurrentDir, $testFramework, '');
             }
 
-            $composerJsonText = file_get_contents('composer.json');
+            $composerJsonText = $this->fileSystem->readFile('composer.json');
 
             $phpUnitPathGuesser = new PhpUnitPathGuesser(json_decode($composerJsonText));
             $defaultValue = $phpUnitPathGuesser->guess();
@@ -111,7 +112,7 @@ final readonly class TestFrameworkConfigPathProvider
                 return $answerDir;
             }
 
-            if (!is_dir($answerDir)) {
+            if (!$this->fileSystem->isReadableDirectory($answerDir)) {
                 throw new RuntimeException(sprintf('Could not find "%s" directory.', $answerDir));
             }
 

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -113,7 +113,7 @@ final readonly class TestFrameworkConfigPathProvider
             }
 
             if (!$this->fileSystem->isReadableDirectory($answerDir)) {
-                throw new RuntimeException(sprintf('Could not find "%s" directory.', $answerDir));
+                throw new RuntimeException(sprintf('Directory "%s" does not exist or is not readable.', $answerDir));
             }
 
             $this->testFrameworkConfigLocator->locate($testFramework, $answerDir);

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -48,7 +48,6 @@ use function Safe\json_decode;
 use function sprintf;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Filesystem\Exception\IOException;
 use function trim;
 
 /**
@@ -66,8 +65,6 @@ final readonly class TestFrameworkConfigPathProvider
 
     /**
      * @param string[] $dirsInCurrentDir
-     *
-     * @throws IOException
      */
     public function get(IO $io, array $dirsInCurrentDir, string $testFramework): ?string
     {

--- a/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
+++ b/src/Config/ValueProvider/TestFrameworkConfigPathProvider.php
@@ -37,10 +37,10 @@ namespace Infection\Config\ValueProvider;
 
 use Closure;
 use Exception;
-use function file_exists;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\Guesser\PhpUnitPathGuesser;
 use Infection\Console\IO;
+use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use Infection\TestFramework\TestFrameworkTypes;
 use function is_dir;
@@ -61,6 +61,7 @@ final readonly class TestFrameworkConfigPathProvider
         private TestFrameworkConfigLocatorInterface $testFrameworkConfigLocator,
         private ConsoleHelper $consoleHelper,
         private QuestionHelper $questionHelper,
+        private FileSystem $fileSystem = new FileSystem(),
     ) {
     }
 
@@ -78,7 +79,7 @@ final readonly class TestFrameworkConfigPathProvider
                 return $this->askTestFrameworkConfigLocation($io, $dirsInCurrentDir, $testFramework, '');
             }
 
-            if (!file_exists('composer.json')) {
+            if (!$this->fileSystem->exists('composer.json')) {
                 return $this->askTestFrameworkConfigLocation($io, $dirsInCurrentDir, $testFramework, '');
             }
 

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -42,7 +42,6 @@ use function array_unique;
 use function array_values;
 use function dirname;
 use function explode;
-use function file_exists;
 use function implode;
 use function in_array;
 use Infection\Configuration\Entry\Logs;
@@ -56,6 +55,7 @@ use Infection\Configuration\SourceFilter\IncompleteGitDiffFilter;
 use Infection\Configuration\SourceFilter\PlainFilter;
 use Infection\Configuration\SourceFilter\PositionalPathsFilter;
 use Infection\Configuration\SourceFilter\SourceFilter;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\FileSystem\TmpDirProvider;
 use Infection\Git\Git;
@@ -104,6 +104,7 @@ class ConfigurationFactory
         private readonly ProjectDirectoryProvider $projectDirectoryProvider,
         private readonly CpuCoresCountProvider $cpuCoresCountProvider,
         private readonly PositionalPathsClassifier $positionalPathsClassifier,
+        private readonly FileSystem $fileSystem = new FileSystem(),
     ) {
     }
 
@@ -240,7 +241,7 @@ class ConfigurationFactory
             return;
         }
 
-        if (!file_exists($bootstrap)) {
+        if (!$this->fileSystem->exists($bootstrap)) {
             throw FileOrDirectoryNotFound::fromFileName($bootstrap, [__DIR__]);
         }
 

--- a/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
+++ b/src/FileSystem/Finder/StaticAnalysisToolExecutableFinder.php
@@ -37,8 +37,8 @@ namespace Infection\FileSystem\Finder;
 
 use function array_key_exists;
 use function dirname;
-use function file_exists;
 use function getenv;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\TestFramework\Contracts\ShellCommandRunner;
 use function ltrim;
@@ -71,6 +71,7 @@ class StaticAnalysisToolExecutableFinder
     public function __construct(
         private readonly ComposerExecutableFinder $executableFinder,
         private readonly ShellCommandRunner $shellCommandRunner,
+        private readonly FileSystem $fileSystem = new FileSystem(),
     ) {
     }
 
@@ -99,7 +100,7 @@ class StaticAnalysisToolExecutableFinder
             return false;
         }
 
-        if (file_exists($customPath)) {
+        if ($this->fileSystem->exists($customPath)) {
             return true;
         }
 
@@ -119,7 +120,7 @@ class StaticAnalysisToolExecutableFinder
         } catch (RuntimeException) {
             $candidate = getcwd() . '/vendor/bin';
 
-            if (file_exists($candidate)) {
+            if ($this->fileSystem->exists($candidate)) {
                 $vendorPath = $candidate;
             }
         }
@@ -193,7 +194,7 @@ class StaticAnalysisToolExecutableFinder
             $target = ltrim(rtrim(trim($match[1]), '" %*'), '\\/');
             $script = realpath(dirname($path) . '/' . $target);
 
-            if (file_exists($script)) {
+            if ($this->fileSystem->exists($script)) {
                 $path = $script;
             }
         }

--- a/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
+++ b/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\StaticAnalysis\Config;
 
-use function file_exists;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use function Safe\realpath;
@@ -57,6 +57,7 @@ final readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigL
 
     public function __construct(
         private string $configDir,
+        private FileSystem $fileSystem = new FileSystem(),
     ) {
     }
 
@@ -68,7 +69,7 @@ final readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigL
         foreach (self::DEFAULT_EXTENSIONS as $extension) {
             $conf = sprintf('%s/%s.%s', $dir, $cliTool, $extension);
 
-            if (file_exists($conf)) {
+            if ($this->fileSystem->exists($conf)) {
                 return realpath($conf);
             }
 

--- a/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
+++ b/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
@@ -38,8 +38,8 @@ namespace Infection\StaticAnalysis\Config;
 use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
-use function Safe\realpath;
 use function sprintf;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * @internal
@@ -61,6 +61,9 @@ final readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigL
     ) {
     }
 
+    /**
+     * @throws IOException
+     */
     public function locate(string $cliTool, ?string $customDir = null): string
     {
         $dir = $customDir ?: $this->configDir;
@@ -70,7 +73,7 @@ final readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigL
             $conf = sprintf('%s/%s.%s', $dir, $cliTool, $extension);
 
             if ($this->fileSystem->exists($conf)) {
-                return realpath($conf);
+                return $this->fileSystem->realPath($conf);
             }
 
             $triedFiles[] = sprintf('%s.%s', $cliTool, $extension);

--- a/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
+++ b/src/StaticAnalysis/Config/StaticAnalysisConfigLocator.php
@@ -39,7 +39,6 @@ use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use function sprintf;
-use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * @internal
@@ -61,9 +60,6 @@ final readonly class StaticAnalysisConfigLocator implements TestFrameworkConfigL
     ) {
     }
 
-    /**
-     * @throws IOException
-     */
     public function locate(string $cliTool, ?string $customDir = null): string
     {
         $dir = $customDir ?: $this->configDir;

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -37,8 +37,8 @@ namespace Infection\TestFramework\Config;
 
 use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
-use function Safe\realpath;
 use function sprintf;
+use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * @internal
@@ -61,6 +61,9 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
     ) {
     }
 
+    /**
+     * @throws IOException
+     */
     public function locate(string $cliTool, ?string $customDir = null): string
     {
         $dir = $customDir ?: $this->configDir;
@@ -70,7 +73,7 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
             $conf = sprintf('%s/%s.%s', $dir, $cliTool, $extension);
 
             if ($this->fileSystem->exists($conf)) {
-                return realpath($conf);
+                return $this->fileSystem->realPath($conf);
             }
 
             $triedFiles[] = sprintf('%s.%s', $cliTool, $extension);

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -38,7 +38,6 @@ namespace Infection\TestFramework\Config;
 use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use function sprintf;
-use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * @internal
@@ -61,9 +60,6 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
     ) {
     }
 
-    /**
-     * @throws IOException
-     */
     public function locate(string $cliTool, ?string $customDir = null): string
     {
         $dir = $customDir ?: $this->configDir;

--- a/src/TestFramework/Config/TestFrameworkConfigLocator.php
+++ b/src/TestFramework/Config/TestFrameworkConfigLocator.php
@@ -35,7 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Config;
 
-use function file_exists;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use function Safe\realpath;
 use function sprintf;
@@ -57,6 +57,7 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
 
     public function __construct(
         private string $configDir,
+        private FileSystem $fileSystem = new FileSystem(),
     ) {
     }
 
@@ -68,7 +69,7 @@ final readonly class TestFrameworkConfigLocator implements TestFrameworkConfigLo
         foreach (self::DEFAULT_EXTENSIONS as $extension) {
             $conf = sprintf('%s/%s.%s', $dir, $cliTool, $extension);
 
-            if (file_exists($conf)) {
+            if ($this->fileSystem->exists($conf)) {
                 return realpath($conf);
             }
 

--- a/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -38,6 +38,7 @@ namespace Infection\Tests\Config\ValueProvider;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\PhpUnitCustomExecutablePathProvider;
 use Infection\Console\IO;
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Finder\Exception\FinderException;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
 use Infection\TestFramework\TestFrameworkTypes;
@@ -46,26 +47,29 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Exception\RuntimeException as SymfonyRuntimeException;
 use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Filesystem\Path;
 
 #[Group('integration')]
 #[CoversClass(PhpUnitCustomExecutablePathProvider::class)]
 final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
 {
-    private const string VALID_PHPUNIT_EXECUTABLE = __DIR__ . '/../../../../vendor/bin/phpunit';
+    private const string CUSTOM_PHPUNIT_EXECUTABLE = '/path/to/vendor/bin/phpunit';
 
     private MockObject&TestFrameworkFinder $finderMock;
+
+    private MockObject&FileSystem $fileSystemMock;
 
     private PhpUnitCustomExecutablePathProvider $provider;
 
     protected function setUp(): void
     {
         $this->finderMock = $this->createMock(TestFrameworkFinder::class);
+        $this->fileSystemMock = $this->createMock(FileSystem::class);
 
         $this->provider = new PhpUnitCustomExecutablePathProvider(
             $this->finderMock,
             $this->createStub(ConsoleHelper::class),
             $this->getQuestionHelper(),
+            $this->fileSystemMock,
         );
     }
 
@@ -75,6 +79,10 @@ final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
             ->expects($this->once())
             ->method('find')
             ->with(TestFrameworkTypes::PHPUNIT);
+
+        $this->fileSystemMock
+            ->expects($this->never())
+            ->method('exists');
 
         $this->assertNull(
             $this->provider->get(new IO(
@@ -92,14 +100,18 @@ final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
             ->with(TestFrameworkTypes::PHPUNIT)
             ->willThrowException(new FinderException());
 
-        $customExecutable = Path::canonicalize(self::VALID_PHPUNIT_EXECUTABLE);
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('exists')
+            ->with(self::CUSTOM_PHPUNIT_EXECUTABLE)
+            ->willReturn(true);
 
         $path = $this->provider->get(new IO(
-            $this->createStreamableInput($this->getInputStream("{$customExecutable}\n")),
+            $this->createStreamableInput($this->getInputStream(self::CUSTOM_PHPUNIT_EXECUTABLE . "\n")),
             $this->createStreamOutput(),
         ));
 
-        $this->assertSame($customExecutable, $path);
+        $this->assertSame(self::CUSTOM_PHPUNIT_EXECUTABLE, $path);
     }
 
     public function test_validates_incorrect_dir(): void
@@ -113,6 +125,12 @@ final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
             ->method('find')
             ->with(TestFrameworkTypes::PHPUNIT)
             ->willThrowException(new FinderException());
+
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('exists')
+            ->with('abc')
+            ->willReturn(false);
 
         $this->expectException(SymfonyRuntimeException::class);
 

--- a/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/PhpUnitCustomExecutablePathProviderTest.php
@@ -83,7 +83,8 @@ final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
 
         $this->fileSystemMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('exists')
+        ;
 
         $this->assertNull(
             $this->provider->get(new IO(
@@ -106,7 +107,8 @@ final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
             ->expects($this->once())
             ->method('exists')
             ->with(self::CUSTOM_PHPUNIT_EXECUTABLE)
-            ->willReturn(true);
+            ->willReturn(true)
+        ;
 
         $path = $this->provider->get(new IO(
             $this->createStreamableInput($this->getInputStream(self::CUSTOM_PHPUNIT_EXECUTABLE . "\n")),
@@ -133,7 +135,8 @@ final class PhpUnitCustomExecutablePathProviderTest extends BaseProviderTestCase
             ->expects($this->once())
             ->method('exists')
             ->with('abc')
-            ->willReturn(false);
+            ->willReturn(false)
+        ;
 
         $this->expectException(SymfonyRuntimeException::class);
 

--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -65,6 +65,7 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         $this->locatorMock = $this->createMock(TestFrameworkConfigLocatorInterface::class);
         $this->consoleMock = $this->createMock(ConsoleHelper::class);
         $this->fileSystemMock = $this->createMock(FileSystem::class);
+
         $this->provider = new TestFrameworkConfigPathProvider(
             $this->locatorMock,
             $this->consoleMock,

--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -83,7 +83,8 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
 
         $this->fileSystemMock
             ->expects($this->never())
-            ->method('exists');
+            ->method('exists')
+        ;
 
         $result = $this->provider->get(
             new IO(
@@ -123,7 +124,8 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
             ->expects($this->once())
             ->method('isReadableDirectory')
             ->with($inputPhpUnitPath)
-            ->willReturn(true);
+            ->willReturn(true)
+        ;
 
         $path = $this->provider->get(
             new IO(
@@ -142,7 +144,8 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         $this->consoleMock
             ->expects($this->once())
             ->method('getQuestion')
-            ->willReturn('foobar');
+            ->willReturn('foobar')
+        ;
 
         $this->locatorMock
             ->expects($this->exactly(2))
@@ -150,17 +153,20 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
             ->willReturnOnConsecutiveCalls(
                 $this->throwException(new Exception()),
                 '',
-            );
+            )
+        ;
 
         $this->fileSystemMock
             ->expects($this->once())
             ->method('exists')
             ->with('composer.json')
-            ->willReturn(false);
+            ->willReturn(false)
+        ;
 
         $this->fileSystemMock
             ->expects($this->never())
-            ->method('readFile');
+            ->method('readFile')
+        ;
 
         $inputPhpUnitPath = '/path/to/phpunit/config';
 
@@ -168,7 +174,8 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
             ->expects($this->once())
             ->method('isReadableDirectory')
             ->with($inputPhpUnitPath)
-            ->willReturn(true);
+            ->willReturn(true)
+        ;
 
         $path = $this->provider->get(
             new IO(
@@ -233,7 +240,8 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
             ->willReturnMap([
                 ['abc', false],
                 ['.', true],
-            ]);
+            ])
+        ;
 
         $path = $this->provider->get(
             new IO(
@@ -253,7 +261,8 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
             ->expects($this->once())
             ->method('exists')
             ->with('composer.json')
-            ->willReturn(true);
+            ->willReturn(true)
+        ;
 
         $this->fileSystemMock
             ->expects($this->once())

--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -39,6 +39,7 @@ use Exception;
 use Infection\Config\ConsoleHelper;
 use Infection\Config\ValueProvider\TestFrameworkConfigPathProvider;
 use Infection\Console\IO;
+use Infection\FileSystem\FileSystem;
 use Infection\TestFramework\Config\TestFrameworkConfigLocatorInterface;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -57,14 +58,18 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
 
     private MockObject&ConsoleHelper $consoleMock;
 
+    private MockObject&FileSystem $fileSystemMock;
+
     protected function setUp(): void
     {
         $this->locatorMock = $this->createMock(TestFrameworkConfigLocatorInterface::class);
         $this->consoleMock = $this->createMock(ConsoleHelper::class);
+        $this->fileSystemMock = $this->createMock(FileSystem::class);
         $this->provider = new TestFrameworkConfigPathProvider(
             $this->locatorMock,
             $this->consoleMock,
             $this->getQuestionHelper(),
+            $this->fileSystemMock,
         );
     }
 
@@ -73,6 +78,10 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         $this->locatorMock
             ->expects($this->once())
             ->method('locate');
+
+        $this->fileSystemMock
+            ->expects($this->never())
+            ->method('exists');
 
         $result = $this->provider->get(
             new IO(
@@ -102,8 +111,15 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
                 '',
             );
 
-        // TODO: it would be better to inject the FS to be able to mock rather than relying on such a value
-        $inputPhpUnitPath = __DIR__;
+        $this->expectComposerJsonIsRead();
+
+        $inputPhpUnitPath = '/path/to/phpunit/config';
+
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('isReadableDirectory')
+            ->with($inputPhpUnitPath)
+            ->willReturn(true);
 
         $path = $this->provider->get(
             new IO(
@@ -115,7 +131,51 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         );
 
         $this->assertSame($inputPhpUnitPath, $path);
-        $this->assertDirectoryExists($path);
+    }
+
+    public function test_it_asks_question_without_guessing_when_there_is_no_composer_json(): void
+    {
+        $this->consoleMock
+            ->expects($this->once())
+            ->method('getQuestion')
+            ->willReturn('foobar');
+
+        $this->locatorMock
+            ->expects($this->exactly(2))
+            ->method('locate')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new Exception()),
+                '',
+            );
+
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('exists')
+            ->with('composer.json')
+            ->willReturn(false);
+
+        $this->fileSystemMock
+            ->expects($this->never())
+            ->method('readFile');
+
+        $inputPhpUnitPath = '/path/to/phpunit/config';
+
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('isReadableDirectory')
+            ->with($inputPhpUnitPath)
+            ->willReturn(true);
+
+        $path = $this->provider->get(
+            new IO(
+                $this->createStreamableInput($this->getInputStream("{$inputPhpUnitPath}\n")),
+                $this->createStreamOutput(),
+            ),
+            [],
+            'phpunit',
+        );
+
+        $this->assertSame($inputPhpUnitPath, $path);
     }
 
     public function test_it_automatically_guesses_path(): void
@@ -131,6 +191,8 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         $this->consoleMock
             ->expects($this->never())
             ->method('getQuestion');
+
+        $this->expectComposerJsonIsRead();
 
         $path = $this->provider->get(
             IO::createNull(),
@@ -156,6 +218,16 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
                 '',
             );
 
+        $this->expectComposerJsonIsRead();
+
+        $this->fileSystemMock
+            ->expects($this->exactly(2))
+            ->method('isReadableDirectory')
+            ->willReturnMap([
+                ['abc', false],
+                ['.', true],
+            ]);
+
         $path = $this->provider->get(
             new IO(
                 $this->createStreamableInput($this->getInputStream("abc\n")),
@@ -166,5 +238,20 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
         );
 
         $this->assertSame('.', $path); // fallbacks to default value
+    }
+
+    private function expectComposerJsonIsRead(): void
+    {
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('exists')
+            ->with('composer.json')
+            ->willReturn(true);
+
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('readFile')
+            ->with('composer.json')
+            ->willReturn('{}');
     }
 }

--- a/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
+++ b/tests/phpunit/Config/ValueProvider/TestFrameworkConfigPathProviderTest.php
@@ -268,6 +268,7 @@ final class TestFrameworkConfigPathProviderTest extends BaseProviderTestCase
             ->expects($this->once())
             ->method('readFile')
             ->with('composer.json')
-            ->willReturn('{}');
+            ->willReturn('{}')
+        ;
     }
 }

--- a/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
+++ b/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
@@ -59,12 +59,14 @@ final class StaticAnalysisConfigLocatorTest extends TestCase
             ->willReturnMap([
                 ['/custom-dir/phpstan.neon', false],
                 ['/custom-dir/phpstan.neon.dist', true],
-            ]);
+            ])
+        ;
         $fileSystemMock
             ->expects($this->once())
             ->method('realPath')
             ->with('/custom-dir/phpstan.neon.dist')
-            ->willReturn('/resolved/phpstan.neon.dist');
+            ->willReturn('/resolved/phpstan.neon.dist')
+        ;
 
         $locator = new StaticAnalysisConfigLocator('/config-dir', $fileSystemMock);
 

--- a/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
+++ b/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\StaticAnalysis\Config;
 
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\StaticAnalysis\Config\StaticAnalysisConfigLocator;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -48,6 +49,27 @@ use Symfony\Component\Filesystem\Path;
 final class StaticAnalysisConfigLocatorTest extends TestCase
 {
     private string $baseDir = __DIR__ . '/../../Fixtures/ConfigLocator/';
+
+    public function test_it_looks_up_and_resolves_the_config_file_via_the_injected_file_system(): void
+    {
+        $fileSystemMock = $this->createMock(FileSystem::class);
+        $fileSystemMock
+            ->expects($this->exactly(2))
+            ->method('exists')
+            ->willReturnMap([
+                ['/custom-dir/phpstan.neon', false],
+                ['/custom-dir/phpstan.neon.dist', true],
+            ]);
+        $fileSystemMock
+            ->expects($this->once())
+            ->method('realPath')
+            ->with('/custom-dir/phpstan.neon.dist')
+            ->willReturn('/resolved/phpstan.neon.dist');
+
+        $locator = new StaticAnalysisConfigLocator('/config-dir', $fileSystemMock);
+
+        $this->assertSame('/resolved/phpstan.neon.dist', $locator->locate('phpstan', '/custom-dir'));
+    }
 
     public function test_it_throws_an_error_if_no_config_file_found(): void
     {

--- a/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
+++ b/tests/phpunit/StaticAnalysis/Config/StaticAnalysisConfigLocatorTest.php
@@ -68,7 +68,9 @@ final class StaticAnalysisConfigLocatorTest extends TestCase
 
         $locator = new StaticAnalysisConfigLocator('/config-dir', $fileSystemMock);
 
-        $this->assertSame('/resolved/phpstan.neon.dist', $locator->locate('phpstan', '/custom-dir'));
+        $actual = $locator->locate('phpstan', '/custom-dir');
+
+        $this->assertSame('/resolved/phpstan.neon.dist', $actual);
     }
 
     public function test_it_throws_an_error_if_no_config_file_found(): void

--- a/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Config;
 
+use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Locator\FileOrDirectoryNotFound;
 use Infection\TestFramework\Config\TestFrameworkConfigLocator;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -48,6 +49,28 @@ use Symfony\Component\Filesystem\Path;
 final class TestFrameworkConfigLocatorTest extends TestCase
 {
     private string $baseDir = __DIR__ . '/../../Fixtures/ConfigLocator/';
+
+    public function test_it_looks_up_and_resolves_the_config_file_via_the_injected_file_system(): void
+    {
+        $fileSystemMock = $this->createMock(FileSystem::class);
+        $fileSystemMock
+            ->expects($this->exactly(3))
+            ->method('exists')
+            ->willReturnMap([
+                ['/config-dir/phpunit.xml', false],
+                ['/config-dir/phpunit.yml', false],
+                ['/config-dir/phpunit.xml.dist', true],
+            ]);
+        $fileSystemMock
+            ->expects($this->once())
+            ->method('realPath')
+            ->with('/config-dir/phpunit.xml.dist')
+            ->willReturn('/resolved/phpunit.xml.dist');
+
+        $locator = new TestFrameworkConfigLocator('/config-dir', $fileSystemMock);
+
+        $this->assertSame('/resolved/phpunit.xml.dist', $locator->locate('phpunit'));
+    }
 
     public function test_it_throws_an_error_if_no_config_file_found(): void
     {

--- a/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -69,7 +69,9 @@ final class TestFrameworkConfigLocatorTest extends TestCase
 
         $locator = new TestFrameworkConfigLocator('/config-dir', $fileSystemMock);
 
-        $this->assertSame('/resolved/phpunit.xml.dist', $locator->locate('phpunit'));
+        $actual = $locator->locate('phpunit');
+
+        $this->assertSame('/resolved/phpunit.xml.dist', $actual);
     }
 
     public function test_it_throws_an_error_if_no_config_file_found(): void

--- a/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
+++ b/tests/phpunit/TestFramework/Config/TestFrameworkConfigLocatorTest.php
@@ -60,12 +60,14 @@ final class TestFrameworkConfigLocatorTest extends TestCase
                 ['/config-dir/phpunit.xml', false],
                 ['/config-dir/phpunit.yml', false],
                 ['/config-dir/phpunit.xml.dist', true],
-            ]);
+            ])
+        ;
         $fileSystemMock
             ->expects($this->once())
             ->method('realPath')
             ->with('/config-dir/phpunit.xml.dist')
-            ->willReturn('/resolved/phpunit.xml.dist');
+            ->willReturn('/resolved/phpunit.xml.dist')
+        ;
 
         $locator = new TestFrameworkConfigLocator('/config-dir', $fileSystemMock);
 


### PR DESCRIPTION
## Description

During the review of #3524 I noticed that we do not use the existing file system abstractions in a few places.

I left the changes to `TestFrameworkFinder` to introduce the same abstraction to PR #3524, so here we change everything else to use the abstraction.


## Reviewer Notes

Since the `FileSystem` class does not have a state, I chose to skip wiring it through the container to reduce the amount of scaffold for no gain.

The slight downside of this approach: `IoCodeDetectorVisitor` treats `new FileSystem()` as IO, so we can't untag the existing tests as integration, but they also do other direct file work - so we couldn't have untagged them anyway.
