### PR TITLE
doc: Add an ADR for the decorators naming conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ Current ADRs:
 - [`adr/0011-use-phpunit-environment-variable-attribute.md`](adr/0011-use-phpunit-environment-variable-attribute.md) - Use PHPUnit attributes for test environment variables
 - [`adr/0012-final-classes-over-final-docblock.md`](adr/0012-final-classes-over-final-docblock.md) - Prefer `final` to `@final` where possible
 - [`adr/0013-public-api-extension-point-registry.md`](adr/0013-public-api-extension-point-registry.md) - Define the public API through an extension-point registry
+- [`adr/0014-decorator-naming.md`](adr/0014-decorator-naming.md) - Decorator naming conventions
 <!-- adr-list:end -->
 
 ## Commands

--- a/adr/0014-decorator-naming.md
+++ b/adr/0014-decorator-naming.md
@@ -1,0 +1,88 @@
+# Decorator naming conventions
+
+## Context
+
+A decorator implements the same contract as another object, delegates to that object and
+adds behaviour. Without a shared naming convention, decorator classes may use a generic
+`Decorator` suffix, while the decorated dependency may be called `$inner`, `$wrapped`,
+`$delegate` or merely repeat the contract name.
+
+Infection names symbols after their domain role and behaviour, not their technical kind or
+the pattern used to implement them. An interface does not receive an `Interface` suffix and
+an exception does not receive an `Exception` suffix. Likewise, `Decorator` identifies an
+implementation pattern, not what a class does. Encoding it in the class name exposes a
+structural detail while leaving callers to discover the useful behaviour elsewhere.
+
+Infection's established decorators describe their added behaviour and retain the decorated
+contract in the class name. For example, `MemoizedSourceCollector` memoizes a
+`SourceCollector`, while `FileLocationReporter` adds file-location output to a `Reporter`.
+Their decorated dependencies are named `$decoratedCollector` and `$decoratedReporter`.
+
+The convention must distinguish the object being decorated from any other collaborator the
+decorator needs. It must also avoid class and property names that describe the implementation
+mechanism without explaining the object's role.
+
+## Decision
+
+Name a decorator `<Behaviour><Contract>`, where `<Behaviour>` describes what the decorator
+adds and `<Contract>` is the short name of the contract it implements. Do not add a
+`Decorator` suffix.
+
+For example, a source collector that memoizes its result is named
+`MemoizedSourceCollector`, not `SourceCollectorDecorator` or
+`MemoizedSourceCollectorDecorator`.
+
+Name the constructor-injected decorated object `$decorated<Role>`, where `<Role>` is the
+principal role noun of the contract, such as `Collector`, `Reporter`, `Iterator`, `Loader`
+or `Mutator`. For example:
+
+```php
+final readonly class MemoizedSourceCollector implements SourceCollector
+{
+    public function __construct(
+        private SourceCollector $decoratedCollector,
+    ) {
+    }
+}
+```
+
+Apply this property convention only to the object that the class decorates. Name additional
+collaborators after their own roles. A factory or another value from which the decorated
+object will later be created is not itself the decorated object and must not use the
+`$decorated<Role>` name.
+
+This decision applies to new and renamed decorators. Existing decorators should be aligned
+when they are changed; adopting this convention does not by itself require unrelated
+renames.
+
+## Consequences
+
+Decorator names communicate both their contract and the behaviour they add. The decorated
+dependency is unambiguous among the class's collaborators, and code search for `decorated`
+can find decorator relationships.
+
+Some existing decorators do not follow this convention. Aligning them may cause internal
+churn and, for public extension points, require a backward-compatibility assessment.
+
+## Enforcement
+
+This convention is enforced during review. Automated enforcement may be added if the
+decorator relationship can be identified without false positives.
+
+## Alternatives considered
+
+Using a `Decorator` suffix makes the implementation pattern explicit, but naming symbols by
+their technical kind is contrary to the project's naming conventions. As with `Interface`
+and `Exception`, the suffix does not explain the symbol's domain role. A generic name such
+as `SourceCollectorDecorator` also omits the behaviour it adds, while
+`MemoizedSourceCollectorDecorator` retains the redundant implementation detail after the
+behaviour and contract already identify the class.
+
+Naming the dependency `$inner`, `$wrapped` or `$delegate` describes a structural detail but
+omits the decorated contract. Naming it `$sourceCollector` does not distinguish it from an
+ordinary collaborator. `$decorated<Role>` communicates both its role and purpose without
+repeating the complete type name.
+
+## Status
+
+Proposed.

--- a/src/Metrics/FilteringResultsCollector.php
+++ b/src/Metrics/FilteringResultsCollector.php
@@ -49,8 +49,8 @@ final readonly class FilteringResultsCollector implements Collector
      * @param DetectionStatus[] $targetDetectionStatuses
      */
     public function __construct(
-        private Collector $targetCollector,
-        private array $targetDetectionStatuses,
+        private Collector $decoratedCollector,
+        private array     $targetDetectionStatuses,
     ) {
     }
 
@@ -62,7 +62,7 @@ final readonly class FilteringResultsCollector implements Collector
         );
 
         if ($filteredExecutionResults !== []) {
-            $this->targetCollector->collect(...$filteredExecutionResults);
+            $this->decoratedCollector->collect(...$filteredExecutionResults);
         }
     }
 }

--- a/src/Metrics/FilteringResultsCollector.php
+++ b/src/Metrics/FilteringResultsCollector.php
@@ -50,7 +50,7 @@ final readonly class FilteringResultsCollector implements Collector
      */
     public function __construct(
         private Collector $decoratedCollector,
-        private array     $targetDetectionStatuses,
+        private array $targetDetectionStatuses,
     ) {
     }
 

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -59,11 +59,11 @@ use function sprintf;
 final readonly class IgnoreMutator implements Mutator
 {
     /**
-     * @param Mutator<TNode> $mutator
+     * @param Mutator<TNode> $decoratedMutator
      */
     public function __construct(
         private IgnoreConfig $config,
-        private Mutator $mutator,
+        private Mutator      $decoratedMutator,
     ) {
     }
 
@@ -80,7 +80,7 @@ final readonly class IgnoreMutator implements Mutator
 
     public function canMutate(Node $node): bool
     {
-        if (!$this->mutator->canMutate($node)) {
+        if (!$this->decoratedMutator->canMutate($node)) {
             return false;
         }
 
@@ -106,11 +106,11 @@ final readonly class IgnoreMutator implements Mutator
      */
     public function mutate(Node $node): iterable
     {
-        return $this->mutator->mutate($node);
+        return $this->decoratedMutator->mutate($node);
     }
 
     public function getName(): string
     {
-        return $this->mutator->getName();
+        return $this->decoratedMutator->getName();
     }
 }

--- a/src/Mutator/IgnoreMutator.php
+++ b/src/Mutator/IgnoreMutator.php
@@ -63,7 +63,7 @@ final readonly class IgnoreMutator implements Mutator
      */
     public function __construct(
         private IgnoreConfig $config,
-        private Mutator      $decoratedMutator,
+        private Mutator $decoratedMutator,
     ) {
     }
 

--- a/src/Mutator/NoopMutator.php
+++ b/src/Mutator/NoopMutator.php
@@ -48,10 +48,10 @@ use function sprintf;
 final readonly class NoopMutator implements Mutator
 {
     /**
-     * @param Mutator<TNode> $mutator
+     * @param Mutator<TNode> $decoratedMutator
      */
     public function __construct(
-        private Mutator $mutator,
+        private Mutator $decoratedMutator,
     ) {
     }
 
@@ -65,7 +65,7 @@ final readonly class NoopMutator implements Mutator
 
     public function canMutate(Node $node): bool
     {
-        return $this->mutator->canMutate($node);
+        return $this->decoratedMutator->canMutate($node);
     }
 
     /**
@@ -80,6 +80,6 @@ final readonly class NoopMutator implements Mutator
 
     public function getName(): string
     {
-        return $this->mutator->getName();
+        return $this->decoratedMutator->getName();
     }
 }

--- a/src/Source/Collector/GitDiffSourceCollector.php
+++ b/src/Source/Collector/GitDiffSourceCollector.php
@@ -48,7 +48,7 @@ use Webmozart\Assert\Assert;
 final readonly class GitDiffSourceCollector implements SourceCollector
 {
     public function __construct(
-        private SourceCollector $innerCollector,
+        private SourceCollector $decoratedCollector,
     ) {
     }
 
@@ -81,7 +81,7 @@ final readonly class GitDiffSourceCollector implements SourceCollector
 
     public function collect(): array
     {
-        return $this->innerCollector->collect();
+        return $this->decoratedCollector->collect();
     }
 
     /**

--- a/src/TestFramework/Coverage/CoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/CoveredTraceProvider.php
@@ -46,7 +46,7 @@ use Infection\TestFramework\Tracing\TraceProvider;
 final readonly class CoveredTraceProvider implements TraceProvider
 {
     public function __construct(
-        private TraceProvider               $decoratedTraceProvider,
+        private TraceProvider $decoratedTraceProvider,
         private JUnitTestExecutionInfoAdder $testFileDataAdder,
     ) {
     }

--- a/src/TestFramework/Coverage/CoveredTraceProvider.php
+++ b/src/TestFramework/Coverage/CoveredTraceProvider.php
@@ -46,7 +46,7 @@ use Infection\TestFramework\Tracing\TraceProvider;
 final readonly class CoveredTraceProvider implements TraceProvider
 {
     public function __construct(
-        private TraceProvider $primaryTraceProvider,
+        private TraceProvider               $decoratedTraceProvider,
         private JUnitTestExecutionInfoAdder $testFileDataAdder,
     ) {
     }
@@ -59,7 +59,7 @@ final readonly class CoveredTraceProvider implements TraceProvider
          * filter will negatively affect performance. The greater the junit.xml report size, the more.
          */
         return $this->testFileDataAdder->addTestExecutionInfo(
-            $this->primaryTraceProvider->provideTraces(),
+            $this->decoratedTraceProvider->provideTraces(),
         );
     }
 }

--- a/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
+++ b/src/TestFramework/Coverage/JUnit/MemoizedTestFileDataProvider.php
@@ -48,14 +48,14 @@ final class MemoizedTestFileDataProvider implements TestFileDataProvider
     private array $cache = [];
 
     public function __construct(
-        private readonly TestFileDataProvider $provider,
+        private readonly TestFileDataProvider $decoratedProvider,
     ) {
     }
 
     public function getTestFileInfo(string $testId): TestFileTimeData
     {
         if (!array_key_exists($testId, $this->cache)) {
-            $this->cache[$testId] = $this->provider->getTestFileInfo($testId);
+            $this->cache[$testId] = $this->decoratedProvider->getTestFileInfo($testId);
         }
 
         return $this->cache[$testId];

--- a/tests/phpunit/TestingUtility/Iterable/NonRewindableIterator.php
+++ b/tests/phpunit/TestingUtility/Iterable/NonRewindableIterator.php
@@ -53,10 +53,10 @@ use Iterator;
 final readonly class NonRewindableIterator implements Iterator
 {
     /**
-     * @param Iterator<TKey, TValue> $iterator
+     * @param Iterator<TKey, TValue> $decoratedIterator
      */
     public function __construct(
-        private Iterator $iterator,
+        private Iterator $decoratedIterator,
     ) {
     }
 
@@ -67,21 +67,21 @@ final readonly class NonRewindableIterator implements Iterator
 
     public function current(): mixed
     {
-        return $this->iterator->current();
+        return $this->decoratedIterator->current();
     }
 
     public function next(): void
     {
-        $this->iterator->next();
+        $this->decoratedIterator->next();
     }
 
     public function key(): mixed
     {
-        return $this->iterator->key();
+        return $this->decoratedIterator->key();
     }
 
     public function valid(): bool
     {
-        return $this->iterator->valid();
+        return $this->decoratedIterator->valid();
     }
 }


### PR DESCRIPTION
Add an ADR to establish the pattern followed when creating a decorator.