### PR TITLE
fix(test-framework): Ensure the resolved Composer bin directory is the correct one

### DIFF
--- a/src/FileSystem/Finder/TestFrameworkFinder.php
+++ b/src/FileSystem/Finder/TestFrameworkFinder.php
@@ -200,6 +200,7 @@ class TestFrameworkFinder
                 ...$this->findComposer(),
                 'config',
                 'bin-dir',
+                '--absolute',
             ]);
 
             if ($binDir !== '') {

--- a/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
+++ b/tests/phpunit/FileSystem/Finder/TestFrameworkFinderTest.php
@@ -35,8 +35,10 @@ declare(strict_types=1);
 
 namespace Infection\Tests\FileSystem\Finder;
 
+use function dirname;
 use function explode;
 use function getenv;
+use function in_array;
 use Infection\FileSystem\Finder\ComposerExecutableFinder;
 use Infection\FileSystem\Finder\ConcreteComposerExecutableFinder;
 use Infection\FileSystem\Finder\Exception\FinderException;
@@ -151,6 +153,46 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         );
     }
 
+    public function test_it_resolves_composer_bin_dir_relative_to_the_composer_configuration(): void
+    {
+        // Setup:
+        //
+        // $tmp/ ← current location
+        // ├── custom-bin/phpunit ← wrong executable
+        // └── configured-project/
+        //     └── custom-bin/phpunit ← executable Composer
+        //
+        chdir($this->tmp);
+
+        $relativeComposerBinDir = 'custom-bin';
+        $this->createPhpUnitExecutableFixture($relativeComposerBinDir);
+
+        $expectedPhpUnitPath = $this->createPhpUnitExecutableFixture(
+            $this->tmp . '/configured-project/' . $relativeComposerBinDir,
+        );
+
+        $shellCommandRunner = $this->createMock(ShellCommandRunner::class);
+        $shellCommandRunner
+            ->expects($this->once())
+            ->method('mustRun')
+            ->willReturnCallback(
+                static fn (array $command): string => in_array('--absolute', $command, true)
+                    ? dirname($expectedPhpUnitPath)
+                    : $relativeComposerBinDir,
+            );
+
+        $expected = realpath($expectedPhpUnitPath);
+
+        $frameworkFinder = new TestFrameworkFinder(
+            $this->composerFinder,
+            $shellCommandRunner,
+        );
+
+        $actual = $frameworkFinder->find(TestFrameworkTypes::PHPUNIT);
+
+        $this->assertSame($expected, $actual);
+    }
+
     public function test_it_falls_back_to_local_vendor_bin_when_composer_command_fails(): void
     {
         chdir($this->tmp);
@@ -165,7 +207,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $shellCommandRunner
             ->expects($this->once())
             ->method('mustRun')
-            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
+            ->with(['/usr/bin/composer', 'config', 'bin-dir', '--absolute'])
             ->willThrowException(new RuntimeException());
 
         $frameworkFinder = new TestFrameworkFinder(
@@ -219,7 +261,7 @@ final class TestFrameworkFinderTest extends FileSystemTestCase
         $shellCommandRunner
             ->expects($this->once())
             ->method('mustRun')
-            ->with(['/usr/bin/composer', 'config', 'bin-dir'])
+            ->with(['/usr/bin/composer', 'config', 'bin-dir', '--absolute'])
             ->willReturn('');
 
         $frameworkFinder = new TestFrameworkFinder(


### PR DESCRIPTION
## Description

While working on `TestFrameworkFinder`, I recently realised that the `::getComposerBinDir()` will return a relative path if the path is resolved via Composer, and an absolute one if it's the fallback, and I wondered if that could be a problem.

From my testing, I could not come up with a possible issue. The setup:

```
/tmp/repro/
├── runner/. ← current working directory
│   └── custom-bin/phpunit
└── configured-project/
    ├── composer.json ← selected using COMPOSER
    └── custom-bin/phpunit
```

And:

```shell
COMPOSER=/tmp/repro/configured-project/composer.json composer config bin-dir
# custom-bin
# taking into account the current working directory this means we are pointing to `/tmp/repro/runner/custom-bin`

COMPOSER=/tmp/repro/configured-project/composer.json composer config bin-dir --absolute
# /tmp/repro/runner/custom-bin
```

So in both cases we are resolving to `/tmp/repro/runner/custom-bin`. Given that even if it didn't, this setup looks quite... questionable.

So this PR is more to provide a consistent result rather than fixing an actual bug. I'm still marking it as Bugfix because I can't argue it's a feature but it's still a change of behaviour so refactor would be inappropriate.
