### PR TITLE
fix(phpunit): Remove the duration test orders when disabling the test run history

### DIFF
--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -43,6 +43,7 @@ use function explode;
 use const FILTER_VALIDATE_URL;
 use function filter_var;
 use function implode;
+use function in_array;
 use Infection\TestFramework\PhpUnit\Config\Path\PathReplacer;
 use Infection\TestFramework\XML\SafeDOMXPath;
 use const LIBXML_ERR_ERROR;
@@ -61,6 +62,20 @@ use Webmozart\Assert\Assert;
  */
 final readonly class XmlConfigurationManipulator
 {
+    /**
+     * The `executionOrder` components PHPUnit 13.3+ reports a test runner warning for when the
+     * recording of the test run history is disabled https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php.
+     * `duration` is the deprecated alias of `duration-ascending`.
+     *
+     * @var list<non-empty-string>
+     */
+    private const array EXECUTION_ORDERS_REQUIRING_TEST_RUN_HISTORY = [
+        'defects',
+        'duration',
+        'duration-ascending',
+        'duration-descending',
+    ];
+
     public function __construct(
         private PathReplacer $pathReplacer,
         private string $phpUnitConfigDir,
@@ -108,8 +123,8 @@ final readonly class XmlConfigurationManipulator
 
         $this->setAttributeValue($xPath, 'recordTestRunHistory', 'false');
 
-        // Ordering tests by defects requires the test run history which is deactivated right above. PHPUnit ignored that combination silently until 13.3 turned it into a test runner warning, which aborts the initial run because of failOnWarning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
-        $this->removeDefectsFromExecutionOrder($xPath);
+        // Ordering tests by defects or by duration requires the test run history which is deactivated right above. PHPUnit ignored that combination silently until 13.3 turned it into a test runner warning, which aborts the initial run because of failOnWarning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
+        $this->removeExecutionOrdersRequiringTestRunHistory($xPath);
     }
 
     public function handleResultCacheAndExecutionOrder(string $version, SafeDOMXPath $xPath, string $mutationHash, string $tmpDir): void
@@ -345,10 +360,12 @@ final readonly class XmlConfigurationManipulator
     }
 
     /**
-     * The `defects` component of `executionOrder` is orthogonal to the other ones, so dropping it
-     * leaves the meaning of the remaining components untouched.
+     * PHPUnit parses the components of `executionOrder` independently from each other: `defects` only
+     * sets the defects-first flag, `depends`/`no-depends` only set the dependency resolution and the
+     * remaining ones set the order itself. Dropping a component hence leaves the meaning of the other
+     * ones untouched; without an order component PHPUnit falls back to its default order.
      */
-    private function removeDefectsFromExecutionOrder(SafeDOMXPath $xPath): void
+    private function removeExecutionOrdersRequiringTestRunHistory(SafeDOMXPath $xPath): void
     {
         $node = $xPath->queryAttribute('/phpunit/@executionOrder');
 
@@ -358,7 +375,7 @@ final readonly class XmlConfigurationManipulator
 
         $orders = array_filter(
             explode(',', (string) $node->nodeValue),
-            static fn (string $order): bool => $order !== 'defects',
+            static fn (string $order): bool => !in_array($order, self::EXECUTION_ORDERS_REQUIRING_TEST_RUN_HISTORY, true),
         );
 
         $node->nodeValue = $orders === [] ? 'default' : implode(',', $orders);

--- a/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
+++ b/src/TestFramework/PhpUnit/Config/XmlConfigurationManipulator.php
@@ -123,7 +123,6 @@ final readonly class XmlConfigurationManipulator
 
         $this->setAttributeValue($xPath, 'recordTestRunHistory', 'false');
 
-        // Ordering tests by defects or by duration requires the test run history which is deactivated right above. PHPUnit ignored that combination silently until 13.3 turned it into a test runner warning, which aborts the initial run because of failOnWarning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
         $this->removeExecutionOrdersRequiringTestRunHistory($xPath);
     }
 
@@ -360,10 +359,16 @@ final readonly class XmlConfigurationManipulator
     }
 
     /**
-     * PHPUnit parses the components of `executionOrder` independently from each other: `defects` only
-     * sets the defects-first flag, `depends`/`no-depends` only set the dependency resolution and the
-     * remaining ones set the order itself. Dropping a component hence leaves the meaning of the other
-     * ones untouched; without an order component PHPUnit falls back to its default order.
+     * Ordering tests by defects or by duration requires the test run history, which the initial run
+     * configuration disables since there is nothing to order by before the first run. PHPUnit ignored
+     * that combination silently until 13.3 turned it into a test runner warning, which aborts the
+     * initial run because of failOnWarning https://github.com/sebastianbergmann/phpunit/blob/13.3.0/src/TextUI/Application.php
+     *
+     * Dropping these components is safe because PHPUnit parses the components of `executionOrder`
+     * independently from each other: `defects` only sets the defects-first flag, `depends`/`no-depends`
+     * only set the dependency resolution and the remaining ones set the order itself. The meaning of
+     * the other components is hence untouched; without an order component PHPUnit falls back to its
+     * default order.
      */
     private function removeExecutionOrdersRequiringTestRunHistory(SafeDOMXPath $xPath): void
     {

--- a/tests/e2e/PHPUnit_13-3/README.md
+++ b/tests/e2e/PHPUnit_13-3/README.md
@@ -3,8 +3,9 @@
 The goal of this test is to ensure Infection works with PHPUnit 13.3+, which deprecated the
 `cacheResult` attribute in favour of `recordTestRunHistory`.
 
-Its `phpunit.xml` orders tests by `defects`, which PHPUnit 13.3 reports as a test runner warning
-when the recording of the test run history is disabled, as the initial run configuration does.
+Its `phpunit.xml` orders tests by `defects` and by `duration-ascending`, which PHPUnit 13.3 reports
+as test runner warnings when the recording of the test run history is disabled, as the initial run
+configuration does.
 
 See:
 

--- a/tests/e2e/PHPUnit_13-3/phpunit.xml
+++ b/tests/e2e/PHPUnit_13-3/phpunit.xml
@@ -5,7 +5,7 @@
          colors="true"
          testdoxSummary="true"
          cacheDirectory="var/phpunit-cache"
-         executionOrder="depends,defects"
+         executionOrder="depends,defects,duration-ascending"
          failOnPhpunitDeprecation="true"
 >
     <testsuites>

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/Fixtures/phpunit_with_order_requiring_test_run_history_set.xml
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/Fixtures/phpunit_with_order_requiring_test_run_history_set.xml
@@ -2,7 +2,7 @@
 <phpunit bootstrap="app/autoload2.php"
          colors="true"
          cacheDirectory=".phpunit.cache"
-         executionOrder="depends,defects"
+         executionOrder="depends,defects,duration-ascending"
 >
     <testsuites>
         <testsuite name="Application Test Suite">

--- a/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/Builder/InitialConfigBuilderTest.php
@@ -470,9 +470,9 @@ final class InitialConfigBuilderTest extends TestCase
         $this->assertSame(0, $resolveDependencies->length);
     }
 
-    public function test_it_removes_the_defects_order_already_set_for_phpunit_13_3(): void
+    public function test_it_removes_the_orders_requiring_the_test_run_history_already_set_for_phpunit_13_3(): void
     {
-        $builder = $this->createConfigBuilder(self::FIXTURES . '/phpunit_with_defects_order_set.xml');
+        $builder = $this->createConfigBuilder(self::FIXTURES . '/phpunit_with_order_requiring_test_run_history_set.xml');
 
         $xml = $this->filesystem->readFile($builder->build('13.3'));
 
@@ -487,16 +487,16 @@ final class InitialConfigBuilderTest extends TestCase
         $this->assertSame('false', $recordTestRunHistory[0]->nodeValue);
     }
 
-    public function test_it_keeps_the_defects_order_already_set_for_phpunit_13_2(): void
+    public function test_it_keeps_the_orders_requiring_the_test_run_history_already_set_for_phpunit_13_2(): void
     {
-        $builder = $this->createConfigBuilder(self::FIXTURES . '/phpunit_with_defects_order_set.xml');
+        $builder = $this->createConfigBuilder(self::FIXTURES . '/phpunit_with_order_requiring_test_run_history_set.xml');
 
         $xml = $this->filesystem->readFile($builder->build('13.2'));
 
         $executionOrder = $this->queryXpath($xml, '/phpunit/@executionOrder');
 
         $this->assertInstanceOf(DOMNodeList::class, $executionOrder);
-        $this->assertSame('depends,defects', $executionOrder[0]->nodeValue);
+        $this->assertSame('depends,defects,duration-ascending', $executionOrder[0]->nodeValue);
     }
 
     #[DataProvider('failOnProvider')]

--- a/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Config/XmlConfigurationManipulatorTest.php
@@ -695,7 +695,7 @@ final class XmlConfigurationManipulatorTest extends TestCase
      * @param non-empty-string $expectedExecutionOrder
      */
     #[DataProvider('executionOrderProvider')]
-    public function test_it_removes_defects_from_the_execution_order_for_phpunit_13_3(string $executionOrder, string $expectedExecutionOrder): void
+    public function test_it_removes_the_execution_orders_requiring_the_test_run_history_for_phpunit_13_3(string $executionOrder, string $expectedExecutionOrder): void
     {
         $this->assertItChangesXML(<<<XML
             <?xml version="1.0" encoding="UTF-8"?>
@@ -726,7 +726,15 @@ final class XmlConfigurationManipulatorTest extends TestCase
 
         yield 'defects last' => ['depends,defects', 'depends'];
 
-        yield 'no defects' => ['depends,random', 'depends,random'];
+        yield 'duration ascending only' => ['duration-ascending', 'default'];
+
+        yield 'duration descending only' => ['duration-descending', 'default'];
+
+        yield 'deprecated duration alias' => ['duration', 'default'];
+
+        yield 'defects and duration' => ['depends,defects,duration-ascending', 'depends'];
+
+        yield 'no order requiring the test run history' => ['depends,random', 'depends,random'];
     }
 
     public function test_it_keeps_the_execution_order_untouched_for_phpunit_13_2(): void


### PR DESCRIPTION
## Description

Since PHPUnit 13.3, ordering tests by duration while the recording of the test run history is disabled is a test runner warning, exactly like ordering by defects:

> Tests cannot be ordered by duration because recording of the test run history is disabled

The initial run configuration sets `recordTestRunHistory="false"` and `failOnWarning="true"`, so on a project whose `phpunit.xml` declares `executionOrder="duration-ascending"` (or `"depends,defects,duration-ascending"`) that warning aborts the run before a single test is executed. Infection then reports `Project tests must be in a passing state before running Infection.` even though the suite is perfectly healthy.

#3458 fixed this for `defects` by stripping that component from `executionOrder` when the history is disabled, but only for `defects`. PHPUnit emits the warning for two things: the defects-first flag and the duration orders (`duration-ascending`, `duration-descending`, and the deprecated `duration` alias, see `TextUI/Application.php` in PHPUnit 13.3). A configuration such as `executionOrder="depends,defects,duration-ascending"` therefore still fails: `defects` is removed, `duration-ascending` is copied verbatim, and PHPUnit refuses to run.

This PR makes the initial run strip every `executionOrder` component that requires the test run history, so the fix from #3458 holds regardless of which of the two orders a project uses. Dropping a component is safe because PHPUnit's config loader parses them independently: `defects` sets the defects-first flag, `depends`/`no-depends` set the dependency resolution, and the remaining values set the order itself. Whatever is left keeps its meaning, and without an order component PHPUnit uses its default order. The initial run does not benefit from any ordering anyway, since there is no history to order by.

## Changes

- Replaces the `defects`-only filter in `XmlConfigurationManipulator::deactivateResultCaching()` with a filter for all `executionOrder` components that require the test run history (`defects`, `duration`, `duration-ascending`, `duration-descending`), listed in a named constant with a link to the PHPUnit check that motivates it. The fallback to `default` when nothing remains is unchanged.
- Extends the `XmlConfigurationManipulatorTest` data provider with the duration cases (each duration value on its own, and `depends,defects,duration-ascending` which is the shape from the report) and renames the test to match.
- Updates the `InitialConfigBuilderTest` fixture to `depends,defects,duration-ascending` (renamed to `phpunit_with_order_requiring_test_run_history_set.xml`) so the builder-level test covers both orders in one go; the 13.2 case still asserts the order is left untouched there.
- Updates the `PHPUnit_13-3` end-to-end scenario to order by `depends,defects,duration-ascending` and its README accordingly. With the source change reverted, this scenario reproduces the reported failure; with it, it completes and matches `expected-output.txt`.

## Checklist

- [x] Tests added/updated
- [ ] Documentation updated (not needed, no user-facing behaviour change beyond the fix)
- [ ] CHANGELOG.md updated (no deprecations or breaking changes)
- [ ] Appropriate labels applied (`bug`)

## Reviewer Notes

- The list of orders lives in a constant rather than in the filter closure so that the PHPUnit reference sits next to the values, and so that a future PHPUnit change only needs a new entry.
- `duration` is included even though PHPUnit 13.3 deprecates it: the loader maps it to `duration-ascending` before the warning check, so it triggers the same warning.
- Verified against PHPUnit 13.3.2: `make cs`, `make phpstan`, `make mago`, `make rector-check` and the two affected unit test files are clean, and the updated e2e scenario passes. Also verified on the real project from the report (`executionOrder="depends,defects,duration-ascending"`, `failOnPhpunitWarning="true"`): the generated initial configuration now contains `executionOrder="depends"` and the initial test run passes.

## Related issues

Follow-up to https://github.com/infection/infection/pull/3458 and https://github.com/infection/infection/issues/3457