### PR TITLE
chore: update git integration test to skip gpg signing

### DIFF
--- a/tests/phpunit/Git/CommandLineGitIntegrationTest.php
+++ b/tests/phpunit/Git/CommandLineGitIntegrationTest.php
@@ -135,6 +135,8 @@ final class CommandLineGitIntegrationTest extends FileSystemTestCase
             'user.name=Infection',
             '-c',
             'user.email=infection@infection.github.io',
+            '-c',
+            'commit.gpgsign=false',
             'commit',
             '--quiet',
             '-m',


### PR DESCRIPTION
## Description

I have gpg signing enabled by default system-wide, and this test keeps failing because I don't have the key for this email. The test already isolates git settings from anything else, but did not isolate from gpg.

## Changes

- Fix the test so it will pass even with mandatory gpg signing.
