### PR TITLE
feat(test-framework): Make test framework factory dependencies explicit

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -3244,7 +3244,7 @@ count = 1
 file = "src/TestFramework/Factory.php"
 code = "deprecated-method"
 message = 'Call to deprecated method: `Infection\TestFramework\Contracts\TestFrameworkFactory::getExecutableName`.'
-count = 2
+count = 1
 
 [[issues]]
 file = "src/TestFramework/Factory.php"
@@ -3262,13 +3262,13 @@ count = 1
 file = "src/TestFramework/Factory.php"
 code = "possibly-static-access-on-interface"
 message = 'Potential static method call on interface `Infection\AbstractTestFramework\TestFrameworkAdapterFactory` via `class-string`.'
-count = 7
+count = 5
 
 [[issues]]
 file = "src/TestFramework/Factory.php"
 code = "possibly-static-access-on-interface"
 message = 'Potential static method call on interface `Infection\TestFramework\Contracts\TestFrameworkFactory` via `class-string`.'
-count = 7
+count = 5
 
 [[issues]]
 file = "src/TestFramework/Factory.php"

--- a/devTools/phpstan-baseline.neon
+++ b/devTools/phpstan-baseline.neon
@@ -775,6 +775,42 @@ parameters:
 			path: ../src/TestFramework/Contracts/TestFramework.php
 
 		-
+			rawMessage: Infection\TestFramework\Contracts\TestFrameworkFactory should not depend on Infection\Configuration\Configuration
+			identifier: phpat.testTestFrameworkContractsStayWithinFuturePackageBoundary
+			count: 1
+			path: ../src/TestFramework/Contracts/TestFrameworkFactory.php
+
+		-
+			rawMessage: Infection\TestFramework\Contracts\TestFrameworkFactory should not depend on Infection\Console\ConsoleOutput
+			identifier: phpat.testTestFrameworkContractsStayWithinFuturePackageBoundary
+			count: 1
+			path: ../src/TestFramework/Contracts/TestFrameworkFactory.php
+
+		-
+			rawMessage: Infection\TestFramework\Contracts\TestFrameworkFactory should not depend on Infection\Process\Factory\MutantProcessContainerFactory
+			identifier: phpat.testTestFrameworkContractsStayWithinFuturePackageBoundary
+			count: 1
+			path: ../src/TestFramework/Contracts/TestFrameworkFactory.php
+
+		-
+			rawMessage: Infection\TestFramework\Contracts\TestFrameworkFactory should not depend on Infection\Process\Runner\InitialTestsRunner
+			identifier: phpat.testTestFrameworkContractsStayWithinFuturePackageBoundary
+			count: 1
+			path: ../src/TestFramework/Contracts/TestFrameworkFactory.php
+
+		-
+			rawMessage: Infection\TestFramework\Contracts\TestFrameworkFactory should not depend on Infection\TestFramework\Coverage\CoverageCheckerFactory
+			identifier: phpat.testTestFrameworkContractsStayWithinFuturePackageBoundary
+			count: 1
+			path: ../src/TestFramework/Contracts/TestFrameworkFactory.php
+
+		-
+			rawMessage: Infection\TestFramework\Contracts\TestFrameworkFactory should not depend on Infection\TestFramework\TestFrameworkExtraOptionsFilter
+			identifier: phpat.testTestFrameworkContractsStayWithinFuturePackageBoundary
+			count: 1
+			path: ../src/TestFramework/Contracts/TestFrameworkFactory.php
+
+		-
 			rawMessage: Function ini_get is unsafe to use. It can return FALSE instead of throwing an exception. Please add 'use function Safe\ini_get;' at the beginning of the file to use the variant provided by the 'thecodingmachine/safe' library.
 			identifier: theCodingMachineSafe.function
 			count: 1

--- a/src/TestFramework/Contracts/TestFrameworkFactory.php
+++ b/src/TestFramework/Contracts/TestFrameworkFactory.php
@@ -35,6 +35,15 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework\Contracts;
 
+use Infection\Configuration\Configuration;
+use Infection\Console\ConsoleOutput;
+use Infection\Process\Factory\MutantProcessContainerFactory;
+use Infection\Process\Runner\InitialTestsRunner;
+use Infection\TestFramework\Coverage\CoverageCheckerFactory;
+use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
+use SplFileInfo;
+use Symfony\Component\Filesystem\Filesystem;
+
 /**
  * Defines how Infection discovers a test framework and creates it from the project's test-run configuration.
  *
@@ -43,6 +52,7 @@ namespace Infection\TestFramework\Contracts;
 interface TestFrameworkFactory
 {
     /**
+     * @param SplFileInfo[] $filteredSourceFilesToMutate
      * @param string[] $sourceDirectories
      */
     public static function create(
@@ -54,6 +64,19 @@ interface TestFrameworkFactory
         string $projectDir,
         array $sourceDirectories,
         bool $skipCoverage,
+        bool $executeOnlyCoveringTestCases,
+        array $filteredSourceFilesToMutate,
+        ?string $mapSourceClassToTestStrategy,
+        ShellCommandRunner $shellCommandRunner,
+        string $sourceDirectoryBasePath,
+        bool $useWindowsFilterLimit,
+        Filesystem $fileSystem,
+        ConsoleOutput $consoleOutput,
+        CoverageCheckerFactory $coverageCheckerFactory,
+        InitialTestsRunner $initialTestsRunner,
+        Configuration $configuration,
+        MutantProcessContainerFactory $processFactory,
+        TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter,
     ): TestFramework;
 
     /**

--- a/src/TestFramework/Contracts/TestFrameworkFactory.php
+++ b/src/TestFramework/Contracts/TestFrameworkFactory.php
@@ -52,8 +52,8 @@ use Symfony\Component\Filesystem\Filesystem;
 interface TestFrameworkFactory
 {
     /**
-     * @param SplFileInfo[] $filteredSourceFilesToMutate
      * @param string[] $sourceDirectories
+     * @param SplFileInfo[] $filteredSourceFilesToMutate
      */
     public static function create(
         string $testFrameworkExecutable,

--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -168,16 +168,40 @@ final readonly class Factory
             if ($adapterName === $factory::getAdapterName()) {
                 $configuration = $this->infectionConfig;
 
-                return $factory::create(
-                    $this->testFrameworkFinder->find($factory::getExecutableName()),
-                    $this->tmpDir,
-                    $this->configLocator->locate($factory::getAdapterName()),
-                    null,
-                    $this->jUnitFilePath,
-                    $this->projectDir,
-                    $configuration->source->directories,
-                    $skipCoverage,
-                );
+                return is_a($factory, TestFrameworkFactory::class, true)
+                    ? $factory::create(
+                        $this->testFrameworkFinder->find($factory::getExecutableName()),
+                        $this->tmpDir,
+                        $this->configLocator->locate($factory::getAdapterName()),
+                        null,
+                        $this->jUnitFilePath,
+                        $this->projectDir,
+                        $configuration->source->directories,
+                        $skipCoverage,
+                        $configuration->executeOnlyCoveringTestCases,
+                        $this->getFilteredSourceFilesToMutate(),
+                        $configuration->mapSourceClassToTestStrategy,
+                        $this->shellCommandRunner,
+                        dirname($configuration->configurationPathname),
+                        OperatingSystem::isWindows(),
+                        $this->fileSystem,
+                        $this->consoleOutput,
+                        $this->coverageCheckerFactory,
+                        $this->initialTestsRunner,
+                        $configuration,
+                        $this->containerFactory,
+                        $this->extraOptionsFilter,
+                    )
+                    : $factory::create(
+                        $this->testFrameworkFinder->find($factory::getExecutableName()),
+                        $this->tmpDir,
+                        $this->configLocator->locate($factory::getAdapterName()),
+                        null,
+                        $this->jUnitFilePath,
+                        $this->projectDir,
+                        $configuration->source->directories,
+                        $skipCoverage,
+                    );
             }
         }
 

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -72,10 +72,6 @@ final class PhpUnitAdapterFactory implements TestFrameworkFactory
 {
     use CannotBeInstantiated;
 
-    /**
-     * @param string[] $sourceDirectories
-     * @param SplFileInfo[] $filteredSourceFilesToMutate
-     */
     public static function create(
         string $testFrameworkExecutable,
         string $tmpDir,
@@ -85,34 +81,25 @@ final class PhpUnitAdapterFactory implements TestFrameworkFactory
         string $projectDir,
         array $sourceDirectories,
         bool $skipCoverage,
-        bool $executeOnlyCoveringTestCases = false,
-        array $filteredSourceFilesToMutate = [],
-        ?string $mapSourceClassToTestStrategy = null,
-        ?ShellCommandRunner $shellCommandRunner = null,
-        ?string $sourceDirectoryBasePath = null,
-        bool $useWindowsFilterLimit = false,
-        ?Filesystem $fileSystem = null,
-        ?ConsoleOutput $consoleOutput = null,
-        ?CoverageCheckerFactory $coverageCheckerFactory = null,
-        ?InitialTestsRunner $initialTestsRunner = null,
-        ?Configuration $configuration = null,
-        ?MutantProcessContainerFactory $processFactory = null,
-        ?TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter = null,
+        bool $executeOnlyCoveringTestCases,
+        array $filteredSourceFilesToMutate,
+        ?string $mapSourceClassToTestStrategy,
+        ShellCommandRunner $shellCommandRunner,
+        string $sourceDirectoryBasePath,
+        bool $useWindowsFilterLimit,
+        Filesystem $fileSystem,
+        ConsoleOutput $consoleOutput,
+        CoverageCheckerFactory $coverageCheckerFactory,
+        InitialTestsRunner $initialTestsRunner,
+        Configuration $configuration,
+        MutantProcessContainerFactory $processFactory,
+        TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter,
     ): TestFramework {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the adapter');
         Assert::notEmpty(
             $sourceDirectories,
             'The source directories cannot be empty. This indicates that an invalid configuration reached the test framework adapter factory.',
         );
-        Assert::notNull($shellCommandRunner);
-        Assert::notNull($sourceDirectoryBasePath);
-        Assert::notNull($fileSystem);
-        Assert::notNull($consoleOutput);
-        Assert::notNull($coverageCheckerFactory);
-        Assert::notNull($initialTestsRunner);
-        Assert::notNull($configuration);
-        Assert::notNull($processFactory);
-        Assert::notNull($testFrameworkExtraOptionsFilter);
 
         $legacyAdapter = self::createLegacy(
             $testFrameworkExecutable,

--- a/tests/Architecture/PHPat/AdapterExtractionBoundariesTest.php
+++ b/tests/Architecture/PHPat/AdapterExtractionBoundariesTest.php
@@ -35,7 +35,9 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat;
 
+use Infection\TestFramework\Contracts\TestFrameworkFactory;
 use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
+use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
 
@@ -81,6 +83,9 @@ final class AdapterExtractionBoundariesTest
     {
         return PHPat::rule()
             ->classes(InfectionSelector::testFrameworkContractCandidate())
+            // The factory still needs Infection services to construct the legacy PHPUnit bridge
+            // while the adapter extraction in #3290 is in progress.
+            ->excluding(Selector::classname(TestFrameworkFactory::class))
             ->canOnly()
             ->dependOn()
             ->classes(

--- a/tests/Architecture/PHPat/AdapterExtractionBoundariesTest.php
+++ b/tests/Architecture/PHPat/AdapterExtractionBoundariesTest.php
@@ -35,9 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Architecture\PHPat;
 
-use Infection\TestFramework\Contracts\TestFrameworkFactory;
 use Infection\Tests\Architecture\PHPat\Selector\InfectionSelector;
-use PHPat\Selector\Selector;
 use PHPat\Test\Builder\Rule;
 use PHPat\Test\PHPat;
 
@@ -83,9 +81,6 @@ final class AdapterExtractionBoundariesTest
     {
         return PHPat::rule()
             ->classes(InfectionSelector::testFrameworkContractCandidate())
-            // The factory still needs Infection services to construct the legacy PHPUnit bridge
-            // while the adapter extraction in #3290 is in progress.
-            ->excluding(Selector::classname(TestFrameworkFactory::class))
             ->canOnly()
             ->dependOn()
             ->classes(

--- a/tests/phpunit/TestFramework/Factory/ConfigurableTestFrameworkFactory.php
+++ b/tests/phpunit/TestFramework/Factory/ConfigurableTestFrameworkFactory.php
@@ -36,8 +36,16 @@ declare(strict_types=1);
 namespace Infection\Tests\TestFramework\Factory;
 
 use Infection\CannotBeInstantiated;
+use Infection\Configuration\Configuration;
+use Infection\Console\ConsoleOutput;
+use Infection\Process\Factory\MutantProcessContainerFactory;
+use Infection\Process\Runner\InitialTestsRunner;
+use Infection\TestFramework\Contracts\ShellCommandRunner;
 use Infection\TestFramework\Contracts\TestFramework;
 use Infection\TestFramework\Contracts\TestFrameworkFactory;
+use Infection\TestFramework\Coverage\CoverageCheckerFactory;
+use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
+use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\Assert\Assert;
 
 final class ConfigurableTestFrameworkFactory implements TestFrameworkFactory
@@ -76,9 +84,6 @@ final class ConfigurableTestFrameworkFactory implements TestFrameworkFactory
         self::$executableName = null;
     }
 
-    /**
-     * @param array<array-key, mixed> $sourceDirectories
-     */
     public static function create(
         string $testFrameworkExecutable,
         string $tmpDir,
@@ -88,6 +93,19 @@ final class ConfigurableTestFrameworkFactory implements TestFrameworkFactory
         string $projectDir,
         array $sourceDirectories,
         bool $skipCoverage,
+        bool $executeOnlyCoveringTestCases,
+        array $filteredSourceFilesToMutate,
+        ?string $mapSourceClassToTestStrategy,
+        ShellCommandRunner $shellCommandRunner,
+        string $sourceDirectoryBasePath,
+        bool $useWindowsFilterLimit,
+        Filesystem $fileSystem,
+        ConsoleOutput $consoleOutput,
+        CoverageCheckerFactory $coverageCheckerFactory,
+        InitialTestsRunner $initialTestsRunner,
+        Configuration $configuration,
+        MutantProcessContainerFactory $processFactory,
+        TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter,
     ): TestFramework {
         $testFramework = self::$testFramework;
         Assert::notNull($testFramework, self::NOT_CONFIGURED_MESSAGE);

--- a/tests/phpunit/TestFramework/Factory/ConfigurableTestFrameworkFactoryTest.php
+++ b/tests/phpunit/TestFramework/Factory/ConfigurableTestFrameworkFactoryTest.php
@@ -35,7 +35,17 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Factory;
 
+use Infection\Console\ConsoleOutput;
+use Infection\FileSystem\FileSystem;
+use Infection\Process\Factory\MutantProcessContainerFactory;
+use Infection\Process\Runner\InitialTestsRunner;
+use Infection\TestFramework\Contracts\ShellCommandRunner;
 use Infection\TestFramework\Contracts\TestFramework;
+use Infection\TestFramework\Coverage\CoverageCheckerFactory;
+use Infection\TestFramework\Coverage\JUnit\JUnitReportLocator;
+use Infection\TestFramework\Coverage\XmlReport\IndexXmlCoverageLocator;
+use Infection\TestFramework\TestFrameworkExtraOptionsFilter;
+use Infection\Tests\Configuration\ConfigurationBuilder;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -50,12 +60,12 @@ final class ConfigurableTestFrameworkFactoryTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{callable(): mixed}>
+     * @return iterable<string, array{callable(self): mixed}>
      */
     public static function provideUnconfiguredOperation(): iterable
     {
         yield 'create test framework' => [
-            static fn () => ConfigurableTestFrameworkFactory::create('', '', '', null, '', '', [], false),
+            static fn (self $test) => $test->createTestFramework(),
         ];
 
         yield 'get adapter name' => [ConfigurableTestFrameworkFactory::getAdapterName(...)];
@@ -73,16 +83,7 @@ final class ConfigurableTestFrameworkFactoryTest extends TestCase
             'dummy-executable',
         );
 
-        $actualTestFramework = ConfigurableTestFrameworkFactory::create(
-            '',
-            '',
-            '',
-            null,
-            '',
-            '',
-            [],
-            false,
-        );
+        $actualTestFramework = $this->createTestFramework();
 
         $this->assertSame($expectedTestFramework, $actualTestFramework);
         $this->assertSame('dummy', ConfigurableTestFrameworkFactory::getAdapterName());
@@ -98,7 +99,7 @@ final class ConfigurableTestFrameworkFactoryTest extends TestCase
             ),
         );
 
-        $operation();
+        $operation($this);
     }
 
     public function test_it_cannot_be_configured_twice_without_reset(): void
@@ -140,7 +141,19 @@ final class ConfigurableTestFrameworkFactoryTest extends TestCase
             'second-executable',
         );
 
-        $actualTestFramework = ConfigurableTestFrameworkFactory::create(
+        $actualTestFramework = $this->createTestFramework();
+
+        $this->assertSame($expectedTestFramework, $actualTestFramework);
+        $this->assertSame('second', ConfigurableTestFrameworkFactory::getAdapterName());
+        $this->assertSame('second-executable', ConfigurableTestFrameworkFactory::getExecutableName());
+    }
+
+    private function createTestFramework(): TestFramework
+    {
+        $configuration = ConfigurationBuilder::withMinimalTestData()->build();
+        $fileSystem = $this->createStub(FileSystem::class);
+
+        return ConfigurableTestFrameworkFactory::create(
             '',
             '',
             '',
@@ -149,10 +162,23 @@ final class ConfigurableTestFrameworkFactoryTest extends TestCase
             '',
             [],
             false,
+            false,
+            [],
+            null,
+            $this->createStub(ShellCommandRunner::class),
+            '',
+            false,
+            $fileSystem,
+            $this->createStub(ConsoleOutput::class),
+            new CoverageCheckerFactory(
+                $configuration,
+                JUnitReportLocator::create($fileSystem, ''),
+                IndexXmlCoverageLocator::create($fileSystem, ''),
+            ),
+            $this->createStub(InitialTestsRunner::class),
+            $configuration,
+            $this->createStub(MutantProcessContainerFactory::class),
+            $this->createStub(TestFrameworkExtraOptionsFilter::class),
         );
-
-        $this->assertSame($expectedTestFramework, $actualTestFramework);
-        $this->assertSame('second', ConfigurableTestFrameworkFactory::getAdapterName());
-        $this->assertSame('second-executable', ConfigurableTestFrameworkFactory::getExecutableName());
     }
 }

--- a/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
+++ b/tests/phpunit/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactoryTest.php
@@ -68,8 +68,12 @@ final class PhpUnitAdapterFactoryTest extends TestCase
             '/path/to/project',
             ['src'],
             true,
+            executeOnlyCoveringTestCases: false,
+            filteredSourceFilesToMutate: [],
+            mapSourceClassToTestStrategy: null,
             shellCommandRunner: new SymfonyProcessShellCommandRunner(),
             sourceDirectoryBasePath: '/path/to/project',
+            useWindowsFilterLimit: false,
             fileSystem: new FileSystem(),
             consoleOutput: $this->createStub(ConsoleOutput::class),
             coverageCheckerFactory: new CoverageCheckerFactory(


### PR DESCRIPTION
## Description

Extend the internal `TestFrameworkFactory::create()` contract with the configuration and services required by the PHPUnit adapter. This lets factories using the new contract receive those dependencies through the common factory path and replaces optional parameters checked at runtime with required, typed arguments.

## Changes

- Add the parameters to the factory contract and forward them from `Factory`.
- Align `PhpUnitAdapterFactory` with the contract, removing defaults and redundant null assertions.
- Temporarily exempt `TestFrameworkFactory` from the future package dependency boundary while it constructs the legacy PHPUnit bridge.

## Related issues

- #2863
