### PR TITLE
refactor(test-framework): Create PHPUnit through the shared test framework factory path

### DIFF
--- a/src/TestFramework/Factory.php
+++ b/src/TestFramework/Factory.php
@@ -35,6 +35,7 @@ declare(strict_types=1);
 
 namespace Infection\TestFramework;
 
+use function array_merge;
 use function dirname;
 use function implode;
 use Infection\AbstractTestFramework\TestFrameworkAdapter;
@@ -118,40 +119,14 @@ final readonly class Factory
             );
         }
 
-        if ($adapterName === TestFrameworkTypes::PHPUNIT) {
-            $phpUnitConfigPath = $this->configLocator->locate(TestFrameworkTypes::PHPUNIT);
+        $availableTestFrameworks = [TestFrameworkTypes::DEBUG];
 
-            return PhpUnitAdapterFactory::create(
-                $this->testFrameworkFinder->find(
-                    TestFrameworkTypes::PHPUNIT,
-                    (string) $this->infectionConfig->phpUnit->customPath,
-                ),
-                $this->tmpDir,
-                $phpUnitConfigPath,
-                (string) $this->infectionConfig->phpUnit->configDir,
-                $this->jUnitFilePath,
-                $this->projectDir,
-                $this->infectionConfig->source->directories,
-                $skipCoverage,
-                $this->infectionConfig->executeOnlyCoveringTestCases,
-                $this->getFilteredSourceFilesToMutate(),
-                $this->infectionConfig->mapSourceClassToTestStrategy,
-                $this->shellCommandRunner,
-                sourceDirectoryBasePath: dirname($this->infectionConfig->configurationPathname),
-                useWindowsFilterLimit: OperatingSystem::isWindows(),
-                fileSystem: $this->fileSystem,
-                consoleOutput: $this->consoleOutput,
-                coverageCheckerFactory: $this->coverageCheckerFactory,
-                initialTestsRunner: $this->initialTestsRunner,
-                configuration: $this->infectionConfig,
-                processFactory: $this->containerFactory,
-                testFrameworkExtraOptionsFilter: $this->extraOptionsFilter,
-            );
-        }
+        $installedExtensions = array_merge(
+            [['extra' => ['class' => PhpUnitAdapterFactory::class]]],
+            $this->installedExtensions,
+        );
 
-        $availableTestFrameworks = [TestFrameworkTypes::PHPUNIT, TestFrameworkTypes::DEBUG];
-
-        foreach ($this->installedExtensions as $installedExtension) {
+        foreach ($installedExtensions as $installedExtension) {
             $factory = $installedExtension['extra']['class'];
 
             Assert::classExists($factory);
@@ -167,13 +142,21 @@ final readonly class Factory
 
             if ($adapterName === $factory::getAdapterName()) {
                 $configuration = $this->infectionConfig;
+                $executableName = $factory::getExecutableName();
+                $isPhpUnit = $factory === PhpUnitAdapterFactory::class;
+                $configPath = $this->configLocator->locate($factory::getAdapterName());
+                $customPath = $isPhpUnit ? (string) $configuration->phpUnit->customPath : '';
+                $configDir = $isPhpUnit ? (string) $configuration->phpUnit->configDir : null;
 
                 return is_a($factory, TestFrameworkFactory::class, true)
                     ? $factory::create(
-                        $this->testFrameworkFinder->find($factory::getExecutableName()),
+                        $this->testFrameworkFinder->find(
+                            $executableName,
+                            $customPath,
+                        ),
                         $this->tmpDir,
-                        $this->configLocator->locate($factory::getAdapterName()),
-                        null,
+                        $configPath,
+                        $configDir,
                         $this->jUnitFilePath,
                         $this->projectDir,
                         $configuration->source->directories,
@@ -193,9 +176,9 @@ final readonly class Factory
                         $this->extraOptionsFilter,
                     )
                     : $factory::create(
-                        $this->testFrameworkFinder->find($factory::getExecutableName()),
+                        $this->testFrameworkFinder->find($executableName),
                         $this->tmpDir,
-                        $this->configLocator->locate($factory::getAdapterName()),
+                        $configPath,
                         null,
                         $this->jUnitFilePath,
                         $this->projectDir,

--- a/tests/phpunit/TestFramework/Factory/FactoryTest.php
+++ b/tests/phpunit/TestFramework/Factory/FactoryTest.php
@@ -35,6 +35,8 @@ declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Factory;
 
+use Infection\Configuration\Configuration;
+use Infection\Configuration\Entry\PhpUnit;
 use Infection\Console\ConsoleOutput;
 use Infection\FileSystem\FileSystem;
 use Infection\FileSystem\Finder\TestFrameworkFinder;
@@ -71,7 +73,7 @@ final class FactoryTest extends TestCase
 
         $this->expectExceptionObject(
             new InvalidArgumentException(
-                'Invalid name of test framework "Fake Test Framework". Available names are: phpunit, debug',
+                'Invalid name of test framework "Fake Test Framework". Available names are: debug, phpunit',
             ),
         );
 
@@ -116,19 +118,53 @@ final class FactoryTest extends TestCase
         $this->assertSame($expectedTestFramework, $testFramework);
     }
 
+    public function test_it_creates_phpunit_with_its_custom_executable(): void
+    {
+        $configuration = ConfigurationBuilder::withMinimalTestData()
+            ->withSourceDirectories('src')
+            ->withPhpUnit(new PhpUnit('config/phpunit', 'bin/phpunit'))
+            ->build()
+        ;
+        $configLocator = $this->createMock(TestFrameworkConfigLocatorInterface::class);
+        $configLocator->expects($this->once())
+            ->method('locate')
+            ->with('phpunit')
+            ->willReturn('/path/to/phpunit.xml')
+        ;
+        $testFrameworkFinder = $this->createMock(TestFrameworkFinder::class);
+        $testFrameworkFinder->expects($this->once())
+            ->method('find')
+            ->with('phpunit', 'bin/phpunit')
+            ->willReturn('/path/to/phpunit')
+        ;
+
+        $factory = $this->createFactory(
+            configuration: $configuration,
+            configLocator: $configLocator,
+            testFrameworkFinder: $testFrameworkFinder,
+        );
+
+        $this->assertSame('PHPUnit', $factory->create('phpunit', false)->getName());
+    }
+
     /**
      * @param array<string, array<string, mixed>> $installedExtensions
      */
-    private function createFactory(array $installedExtensions = []): Factory
-    {
-        $configuration = ConfigurationBuilder::withMinimalTestData()->build();
+    private function createFactory(
+        array $installedExtensions = [],
+        ?Configuration $configuration = null,
+        ?TestFrameworkConfigLocatorInterface $configLocator = null,
+        ?TestFrameworkFinder $testFrameworkFinder = null,
+    ): Factory {
+        $configuration ??= ConfigurationBuilder::withMinimalTestData()->build();
         $fileSystem = $this->createStub(FileSystem::class);
+        $fileSystem->method('readFile')->willReturn('<phpunit/>');
 
         return new Factory(
             '',
             '',
-            $this->createStub(TestFrameworkConfigLocatorInterface::class),
-            $this->createStub(TestFrameworkFinder::class),
+            $configLocator ?? $this->createStub(TestFrameworkConfigLocatorInterface::class),
+            $testFrameworkFinder ?? $this->createStub(TestFrameworkFinder::class),
             '',
             $configuration,
             new FakeSourceCollector(),


### PR DESCRIPTION
## Description

Remove the dedicated creation path for the PHPUnit adapter. The factory contract update in https://github.com/infection/infection/pull/3562 allows PHPUnit to use the same creation path as other adapters.

A few minor cases of PHPUnit-specific handling remain, identified by `$isPhpunit`. These will be addressed in future PRs.

## Changes

- Prepend the built-in `PhpUnitAdapterFactory` to the discovered factories and remove its dedicated creation branch.
- Supply PHPUnit-specific paths in the shared creation path while preserving the legacy adapter factory call.
- Add a regression test for PHPUnit's custom executable and update the expected available-framework order to `debug, phpunit`.

## Related issues

- https://github.com/infection/infection/issues/2863