### PR TITLE
refactor(configuration, test-framework): Require non-empty source directories

### DIFF
--- a/devTools/mago-baseline.toml
+++ b/devTools/mago-baseline.toml
@@ -4171,6 +4171,12 @@ message = "Reference created from a previously undefined variable `$output`."
 count = 1
 
 [[issues]]
+file = "tests/phpunit/Configuration/PositionalPathsClassifier/Scenario.php"
+code = "possibly-invalid-argument"
+message = 'Possible argument type mismatch for argument #2 of `Infection\Tests\Configuration\PositionalPathsClassifier\Scenario::__construct`: expected `non-empty-list<non-empty-string>`, but possibly received `array{}`.'
+count = 1
+
+[[issues]]
 file = "tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php"
 code = "mixed-argument"
 message = 'Invalid argument type for argument #2 of `Infection\Configuration\Schema\SchemaConfigurationFactory::create`: expected `stdClass`, but found `mixed`.'

--- a/infection.json5
+++ b/infection.json5
@@ -4,7 +4,7 @@
     "threads": "max",
     "source": {
         "directories": [
-            "src"
+            ""
         ],
         excludes: [
             "FileSystem/DummyFileSystem.php",

--- a/src/Configuration/Entry/Source.php
+++ b/src/Configuration/Entry/Source.php
@@ -41,12 +41,12 @@ namespace Infection\Configuration\Entry;
 final readonly class Source
 {
     /**
-     * @param list<non-empty-string> $directories
+     * @param non-empty-list<non-empty-string> $directories
      * @param list<non-empty-string> $excludes
      */
     public function __construct(
-        public array $directories = [],
-        public array $excludes = [],
+        public array $directories,
+        public array $excludes,
     ) {
     }
 }

--- a/src/Configuration/Schema/SchemaConfigurationFactory.php
+++ b/src/Configuration/Schema/SchemaConfigurationFactory.php
@@ -148,8 +148,16 @@ class SchemaConfigurationFactory
 
     private static function createSource(stdClass $source): Source
     {
+        $sourceDirectories = self::normalizeStringArray($source->directories ?? []);
+        // TODO: for consistency we should throw InvalidSchema here; likewise for other exceptions
+        //   and document the @throws
+        Assert::notEmpty(
+            $sourceDirectories,
+            'The source directories cannot be empty. This indicates that an invalid configuration reached the test framework adapter factory.',
+        );
+
         return new Source(
-            self::normalizeStringArray($source->directories ?? []),
+            $sourceDirectories,
             self::normalizeStringArray($source->excludes ?? []),
         );
     }

--- a/src/TestFramework/Contracts/TestFrameworkFactory.php
+++ b/src/TestFramework/Contracts/TestFrameworkFactory.php
@@ -52,7 +52,7 @@ use Symfony\Component\Filesystem\Filesystem;
 interface TestFrameworkFactory
 {
     /**
-     * @param string[] $sourceDirectories
+     * @param non-empty-array<string> $sourceDirectories
      * @param SplFileInfo[] $filteredSourceFilesToMutate
      */
     public static function create(

--- a/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
+++ b/src/TestFramework/PhpUnit/Adapter/PhpUnitAdapterFactory.php
@@ -96,10 +96,6 @@ final class PhpUnitAdapterFactory implements TestFrameworkFactory
         TestFrameworkExtraOptionsFilter $testFrameworkExtraOptionsFilter,
     ): TestFramework {
         Assert::string($testFrameworkConfigDir, 'Config dir is not allowed to be `null` for the adapter');
-        Assert::notEmpty(
-            $sourceDirectories,
-            'The source directories cannot be empty. This indicates that an invalid configuration reached the test framework adapter factory.',
-        );
 
         $legacyAdapter = self::createLegacy(
             $testFrameworkExecutable,

--- a/tests/phpunit/Configuration/ConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/ConfigurationBuilder.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 
 namespace Infection\Tests\Configuration;
 
+use function array_unshift;
 use function array_values;
 use function implode;
 use Infection\Configuration\Configuration;
@@ -159,7 +160,7 @@ final class ConfigurationBuilder
     {
         return new self(
             timeout: 10.0,
-            source: new Source(),
+            source: new Source(['src'], []),
             sourceFilter: null,
             logs: Logs::createEmpty(),
             logVerbosity: 'none',
@@ -286,10 +287,15 @@ final class ConfigurationBuilder
     }
 
     /**
+     * @param non-empty-string $sourceDirectory
      * @param non-empty-string ...$sourceDirectories
      */
-    public function withSourceDirectories(string ...$sourceDirectories): self
-    {
+    public function withSourceDirectories(
+        string $sourceDirectory,
+        string ...$sourceDirectories,
+    ): self {
+        array_unshift($sourceDirectories, $sourceDirectory);
+
         $clone = clone $this;
         $clone->source = new Source(
             array_values($sourceDirectories),

--- a/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/ConfigurationFactory/ConfigurationFactoryTest.php
@@ -130,32 +130,7 @@ final class ConfigurationFactoryTest extends TestCase
 
     public function test_it_throws_exception_when_not_known_static_analysis_tool_used_as_input(): void
     {
-        $schema = new SchemaConfiguration(
-            pathname: '/path/to/infection.json',
-            timeout: null,
-            source: new Source([], []),
-            logs: Logs::createEmpty(),
-            tmpDir: '',
-            phpUnit: new PhpUnit(null, null),
-            phpStan: new PhpStan(null, null),
-            mago: new Mago(null, null),
-            ignoreMsiWithNoMutations: null,
-            minMsi: null,
-            minCoveredMsi: null,
-            timeoutsAsEscaped: null,
-            maxTimeouts: null,
-            mutators: [],
-            testFramework: TestFrameworkTypes::PHPUNIT,
-            bootstrap: null,
-            initialTestsPhpOptions: null,
-            testFrameworkExtraOptions: null,
-            testFrameworkExtraArgs: null,
-            staticAnalysisToolOptions: null,
-            threads: null,
-            dotsPerRow: null,
-            staticAnalysisTool: StaticAnalysisToolTypes::PHPSTAN,
-            debugTestFrameworkLogFile: null,
-        );
+        $schema = SchemaConfigurationBuilder::withMinimalTestData()->build();
 
         $this->expectExceptionMessage('Expected one of: "phpstan", "mago", "debug". Got: "non-supported-static-analysis-tool"');
 
@@ -216,7 +191,7 @@ final class ConfigurationFactoryTest extends TestCase
         $defaultSchema = new SchemaConfiguration(
             pathname: '/path/to/infection.json',
             timeout: null,
-            source: new Source([], []),
+            source: new Source(['src'], []),
             logs: Logs::createEmpty(),
             tmpDir: '',
             phpUnit: new PhpUnit(null, null),
@@ -280,7 +255,7 @@ final class ConfigurationFactoryTest extends TestCase
 
         $defaultConfiguration = new Configuration(
             processTimeout: 10,
-            source: new Source(),
+            source: new Source(['src'], []),
             sourceFilter: new GitDiffFilter('AM', 'reference(master)'),
             logs: $defaultLogs,
             logVerbosity: LogVerbosity::NONE,

--- a/tests/phpunit/Configuration/PositionalPathsClassifier/PositionalPathsClassifierTest.php
+++ b/tests/phpunit/Configuration/PositionalPathsClassifier/PositionalPathsClassifierTest.php
@@ -182,14 +182,6 @@ final class PositionalPathsClassifierTest extends TestCase
                 ->withExpected(new ClassifiedPaths(['lib/B.php'], ['tests/CTest.php'])),
         ];
 
-        yield 'no configured source directories routes existing paths to test' => [
-            $baseScenario
-                ->withPaths(['src/SomeFile.php'])
-                ->withSourceDirectories([])
-                ->withExistingFiles(['/project/src/SomeFile.php'])
-                ->withExpected(new ClassifiedPaths([], ['src/SomeFile.php'])),
-        ];
-
         yield 'singular test directory file path' => [
             $baseScenario
                 ->withPaths(['test/Foo.php'])

--- a/tests/phpunit/Configuration/PositionalPathsClassifier/Scenario.php
+++ b/tests/phpunit/Configuration/PositionalPathsClassifier/Scenario.php
@@ -49,7 +49,7 @@ final class Scenario
 
     /**
      * @param list<non-empty-string> $paths
-     * @param list<non-empty-string> $sourceDirectories
+     * @param non-empty-list<non-empty-string> $sourceDirectories
      * @param list<non-empty-string> $existingFiles
      * @param list<non-empty-string> $existingDirectories
      */
@@ -67,6 +67,7 @@ final class Scenario
     {
         return new self(
             paths: [],
+            // @phpstan-ignore argument.type
             sourceDirectories: [],
             existingFiles: [],
             existingDirectories: [],
@@ -89,7 +90,7 @@ final class Scenario
     }
 
     /**
-     * @param list<non-empty-string> $sourceDirectories
+     * @param non-empty-list<non-empty-string> $sourceDirectories
      */
     public function withSourceDirectories(array $sourceDirectories): self
     {
@@ -152,7 +153,7 @@ final class Scenario
     }
 
     /**
-     * @param list<non-empty-string> $sourceDirectories
+     * @param non-empty-list<non-empty-string> $sourceDirectories
      */
     private static function createSchema(array $sourceDirectories): SchemaConfiguration
     {

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationBuilder.php
@@ -117,7 +117,7 @@ final class SchemaConfigurationBuilder
         return new self(
             pathname: '/path/to/infection.json',
             timeout: null,
-            source: new Source([], []),
+            source: new Source(['src'], []),
             logs: Logs::createEmpty(),
             tmpDir: null,
             phpUnit: new PhpUnit(null, null),

--- a/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
+++ b/tests/phpunit/Configuration/Schema/SchemaConfigurationFactoryTest.php
@@ -180,19 +180,21 @@ final class SchemaConfigurationFactoryTest extends TestCase
             ]),
         ];
 
-        yield '[source] empty strings' => [
-            <<<'JSON'
-                {
-                    "source": {
-                        "directories": [""],
-                        "excludes": [""]
-                    }
-                }
-                JSON,
-            self::createConfig([
-                'source' => new Source([], []),
-            ]),
-        ];
+        // TODO: invalid scenario, but may be worth have a test for such invalid scenarios, we dealing with user-input
+        //   so asserting the exception + message has an importance in terms of UX.
+        // yield '[source] empty strings' => [
+        //    <<<'JSON'
+        //        {
+        //            "source": {
+        //                "directories": [""],
+        //                "excludes": [""]
+        //            }
+        //        }
+        //        JSON,
+        //    self::createConfig([
+        //        'source' => new Source([], []),
+        //    ]),
+        // ];
 
         yield '[source] empty & untrimmed strings' => [
             <<<'JSON'
@@ -2779,7 +2781,7 @@ final class SchemaConfigurationFactoryTest extends TestCase
         $defaultArgs = [
             'path' => '/path/to/config',
             'timeout' => null,
-            'source' => new Source([], []),
+            'source' => new Source(['src'], []),
             'logs' => Logs::createEmpty(),
             'tmpDir' => null,
             'phpunit' => new PhpUnit(null, null),

--- a/tests/phpunit/TestFramework/Factory/ConfigurableTestFrameworkFactoryTest.php
+++ b/tests/phpunit/TestFramework/Factory/ConfigurableTestFrameworkFactoryTest.php
@@ -160,7 +160,7 @@ final class ConfigurableTestFrameworkFactoryTest extends TestCase
             null,
             '',
             '',
-            [],
+            ['src'],
             false,
             false,
             [],


### PR DESCRIPTION
## Description

The PHPUnitAdapter requires `$sourceDirectories` to be a non-empty array. In practice, this is already guaranteed by infection, via the Schema file validation itself and the Schema factory. It was, however, not enforced at the type level. This PR addresses this.

_marked as draft: changing this specific point highlighted a few more tests gaps that deserve to be treated in their own PRs independently_

## Changes

- Declare non-empty source-directory types on `Source` and `TestFrameworkFactory`, and remove the `Source` constructor defaults.
- Assert that normalised source directories are non-empty in `SchemaConfigurationFactory` and remove the redundant PHPUnit assertion.
- Update test builders and fixtures to supply source directories; remove the empty-directory classifier case and comment out the empty-string schema case.
- Add a PHPStan suppression and Mago baseline entry for the empty scenario builder, and change the repository's `infection.json5` source directory from `"src"` to `""`.


## Related issues

- https://github.com/infection/infection/issues/2863.
